### PR TITLE
PERSONDIR-66

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/.settings
+/.project
+/.classpath
+/target

--- a/person-directory-api/.gitignore
+++ b/person-directory-api/.gitignore
@@ -1,0 +1,4 @@
+/.settings
+/.project
+/.classpath
+/target

--- a/person-directory-impl/.gitignore
+++ b/person-directory-impl/.gitignore
@@ -1,0 +1,4 @@
+/.settings
+/.project
+/.classpath
+/target

--- a/person-directory-impl/src/main/java/org/jasig/services/persondir/support/AbstractQueryPersonAttributeDao.java
+++ b/person-directory-impl/src/main/java/org/jasig/services/persondir/support/AbstractQueryPersonAttributeDao.java
@@ -392,8 +392,13 @@ public abstract class AbstractQueryPersonAttributeDao<QB> extends AbstractDefaul
     }
     
     /**
-     * @return The appropriate attribute to user for the user name. Since {@link #getDefaultAttributeName()} should
-     * never return null this method should never return null either.
+     * Indicates which attribute found by the subclass should be taken as the 
+     * 'username' attribute.  (E.g. 'uid' or 'sAMAccountName')  NOTE:  Any two 
+     * instances if BasePersonImpl with the same username are considered 
+     * equal.  Since {@link #getDefaultAttributeName()} should never return 
+     * null, this method should never return null either.
+     * 
+     * @return The name of the attribute corresponding to the  user's username. 
      */
     protected String getConfiguredUserNameAttribute() {
         //If configured explicitly use it
@@ -403,5 +408,18 @@ public abstract class AbstractQueryPersonAttributeDao<QB> extends AbstractDefaul
         
         final IUsernameAttributeProvider usernameAttributeProvider = this.getUsernameAttributeProvider();
         return usernameAttributeProvider.getUsernameAttribute();
+    }
+    
+    /**
+     * Indicates whether the value from {@link #getConfiguredUserNameAttribute()} 
+     * was configured explicitly.  A return value of <code>false</code> means 
+     * that the value from {@link #getConfiguredUserNameAttribute()} is a 
+     * default, and should not be used over a username passed in the query.
+     * 
+     * @return <code>true</code> If the 'unmappedUsernameAttribute' property was 
+     * set explicitly, otherwise <code>false</code>
+     */
+    protected boolean isUserNameAttributeConfigured() {
+        return this.unmappedUsernameAttribute != null;
     }
 }

--- a/person-directory-impl/src/main/java/org/jasig/services/persondir/support/ComplexStubPersonAttributeDao.java
+++ b/person-directory-impl/src/main/java/org/jasig/services/persondir/support/ComplexStubPersonAttributeDao.java
@@ -206,19 +206,29 @@ public class ComplexStubPersonAttributeDao extends AbstractQueryPersonAttributeD
 
     private IPersonAttributes createPerson(String seedValue, String queryUserName, Map<String, List<Object>> attributes) {
         final IPersonAttributes person;
-        if (queryUserName != null) {
+        final String userNameAttribute = this.getConfiguredUserNameAttribute();
+        if (this.isUserNameAttributeConfigured() && attributes.containsKey(userNameAttribute)) {
+            // Option #1:  An attribute is named explicitly in the config, 
+            // and that attribute is present in the results from LDAP;  use it
+            person = new AttributeNamedPersonImpl(userNameAttribute, attributes);
+        } else if (queryUserName != null) {
+            // Option #2:  Use the userName attribute provided in the query 
+            // parameters.  (NB:  I'm not entirely sure this choice is 
+            // preferable to Option #3.  Keeping it because it most closely 
+            // matches the legacy behavior there the new option -- Option #1 
+            // -- doesn't apply.  ~drewwills)
             person = new NamedPersonImpl(queryUserName, attributes);
-        }
-        else {
-            final String usernameAttribute = this.getConfiguredUserNameAttribute();
-            
-            if (seedValue != null && usernameAttribute.equals(this.queryAttributeName)) {
+        } else {
+            // Option #3:  Create the IPersonAttributes doing a best-guess 
+            // at a userName attribute
+            if (seedValue != null && userNameAttribute.equals(this.queryAttributeName)) {
                 person = new NamedPersonImpl(seedValue, attributes);
             }
             else {
-                person = new AttributeNamedPersonImpl(usernameAttribute, attributes);
+                person = new AttributeNamedPersonImpl(userNameAttribute, attributes);
             }
         }
+
         return person;
     }
 

--- a/person-directory-impl/src/main/java/org/jasig/services/persondir/support/jdbc/SingleRowJdbcPersonAttributeDao.java
+++ b/person-directory-impl/src/main/java/org/jasig/services/persondir/support/jdbc/SingleRowJdbcPersonAttributeDao.java
@@ -99,12 +99,21 @@ public class SingleRowJdbcPersonAttributeDao extends AbstractJdbcPersonAttribute
             final Map<String, List<Object>> multivaluedQueryResult = MultivaluedPersonAttributeUtils.toMultivaluedMap(queryResult);
             
             final IPersonAttributes person;
-            if (queryUserName != null) {
+            final String userNameAttribute = this.getConfiguredUserNameAttribute();
+            if (this.isUserNameAttributeConfigured() && queryResult.containsKey(userNameAttribute)) {
+                // Option #1:  An attribute is named explicitly in the config, 
+                // and that attribute is present in the results from LDAP;  use it
+                person = new CaseInsensitiveAttributeNamedPersonImpl(userNameAttribute, multivaluedQueryResult);
+            } else if (queryUserName != null) {
+                // Option #2:  Use the userName attribute provided in the query 
+                // parameters.  (NB:  I'm not entirely sure this choice is 
+                // preferable to Option #3.  Keeping it because it most closely 
+                // matches the legacy behavior there the new option -- Option #1 
+                // -- doesn't apply.  ~drewwills)
                 person = new CaseInsensitiveNamedPersonImpl(queryUserName, multivaluedQueryResult);
-            }
-            else {
-                //Create the IPersonAttributes doing a best-guess at a userName attribute
-                final String userNameAttribute = this.getConfiguredUserNameAttribute();
+            } else {
+                // Option #3:  Create the IPersonAttributes doing a best-guess 
+                // at a userName attribute
                 person = new CaseInsensitiveAttributeNamedPersonImpl(userNameAttribute, multivaluedQueryResult);
             }
             

--- a/person-directory-impl/src/main/java/org/jasig/services/persondir/support/ldap/LdapPersonAttributeDao.java
+++ b/person-directory-impl/src/main/java/org/jasig/services/persondir/support/ldap/LdapPersonAttributeDao.java
@@ -203,12 +203,23 @@ public class LdapPersonAttributeDao extends AbstractQueryPersonAttributeDao<Logi
         final List<IPersonAttributes> peopleAttributes = new ArrayList<IPersonAttributes>(queryResults.size());
         for (final Map<String, List<Object>> queryResult : queryResults) {
             final IPersonAttributes person;
-            if (queryUserName != null) {
+
+            // Choose a username from the best available option
+            final String userNameAttribute = this.getConfiguredUserNameAttribute();
+            if (this.isUserNameAttributeConfigured() && queryResult.containsKey(userNameAttribute)) {
+                // Option #1:  An attribute is named explicitly in the config, 
+                // and that attribute is present in the results from LDAP;  use it
+                person = new CaseInsensitiveAttributeNamedPersonImpl(userNameAttribute, queryResult);
+            } else if (queryUserName != null) {
+                // Option #2:  Use the userName attribute provided in the query 
+                // parameters.  (NB:  I'm not entirely sure this choice is 
+                // preferable to Option #3.  Keeping it because it most closely 
+                // matches the legacy behavior there the new option -- Option #1 
+                // -- doesn't apply.  ~drewwills)
                 person = new CaseInsensitiveNamedPersonImpl(queryUserName, queryResult);
-            }
-            else {
-                //Create the IPersonAttributes doing a best-guess at a userName attribute
-                final String userNameAttribute = this.getConfiguredUserNameAttribute();
+            } else {
+                // Option #3:  Create the IPersonAttributes doing a best-guess 
+                // at a userName attribute
                 person = new CaseInsensitiveAttributeNamedPersonImpl(userNameAttribute, queryResult);
             }
             


### PR DESCRIPTION
Subclasses of AbstractQueryPersonAttributeDao pull username from the query parameters when they probably shouldn't

This patch addresses the JIRA but takes the tactic of making the fewest possible changes to existing behavior.  Specifically, it uses the following approach for selecting a username:
- Option #1:  An attribute is named explicitly in the config, and that attribute is present in the results from LDAP;  use it
- Option #2:  Use the userName attribute provided in the query parameters.
- Option #3:  Create the IPersonAttributes doing a best-guess at a userName attribute

So if a userName attribute is _explicitly configured_ for the bean, and that attribute is present in the result set, it will prefer it;  otherwise it will do what it did before the patch.

I think there's a good argument that the userName attribute should be preferred more often (even when not configured explicitly), but at this point I'm unsure what systems are relying on the old behavior, and what all the outcomes would be.
