### PR TITLE
SSP-1668 Support case-insensitive query, result and data attrib values

### DIFF
--- a/person-directory-impl/src/main/java/org/jasig/services/persondir/support/AbstractQueryPersonAttributeDao.java
+++ b/person-directory-impl/src/main/java/org/jasig/services/persondir/support/AbstractQueryPersonAttributeDao.java
@@ -19,16 +19,20 @@
 
 package org.jasig.services.persondir.support;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.lang.Validate;
 import org.jasig.services.persondir.IPersonAttributes;
+import org.jasig.services.persondir.util.CaseCanonicalizationMode;
 
 /**
  * Provides common functionality for DAOs using a set of attribute values from the seed to
@@ -90,8 +94,15 @@ import org.jasig.services.persondir.IPersonAttributes;
  * @version $Revision$
  */
 public abstract class AbstractQueryPersonAttributeDao<QB> extends AbstractDefaultAttributePersonAttributeDao {
+    public static final CaseCanonicalizationMode DEFAULT_CASE_CANONICALIZATION_MODE = CaseCanonicalizationMode.LOWER;
+    public static final CaseCanonicalizationMode DEFAULT_USERNAME_CASE_CANONICALIZATION_MODE = CaseCanonicalizationMode.NONE;
     private Map<String, Set<String>> queryAttributeMapping;
     private Map<String, Set<String>> resultAttributeMapping;
+    private Map<String, CaseCanonicalizationMode> caseInsensitiveResultAttributes;
+    private Map<String, CaseCanonicalizationMode> caseInsensitiveQueryAttributes;
+    private CaseCanonicalizationMode defaultCaseCanonicalizationMode = DEFAULT_CASE_CANONICALIZATION_MODE;
+    private CaseCanonicalizationMode usernameCaseCanonicalizationMode = DEFAULT_USERNAME_CASE_CANONICALIZATION_MODE;
+    private Locale caseCanonicalizationLocale = Locale.getDefault();
     private Set<String> possibleUserAttributes;
     private boolean requireAllQueryAttributes = false;
     private boolean useAllQueryAttributes = true;
@@ -261,6 +272,50 @@ public abstract class AbstractQueryPersonAttributeDao<QB> extends AbstractDefaul
     protected abstract List<IPersonAttributes> getPeopleForQuery(QB queryBuilder, String queryUserName);
 
     /**
+     * Append the attribute and its canonicalized value/s to the
+     * {@code queryBuilder}. Uses {@code queryAttribute} to determine whether or
+     * not the value/s should be canonicalized. I.e. the behavior is controlled
+     * by {@link #setCaseInsensitiveQueryAttributes(java.util.Map)}.
+     *
+     * <p>This method is only concerned with canonicalizing the query attribute
+     * value. It is still up to the subclass to canonicalize the data-layer
+     * attribute value prior to comparison, if necessary. For example, if
+     * the data layer is a case-sensitive relational database and attributes
+     * therein are stored in mixed case, but comparison should be
+     * case-insensitive, the relational column reference would need to be
+     * wrapped in a {@code lower()} or {@code upper()} function. (This, of
+     * course, needs to be handled with care, since it can lead to table
+     * scanning if the store does not support function-based indexes.) Such
+     * data-layer canonicalization would be unnecessary if the data layer is
+     * case-insensitive or stores values in the same canonicalized form as has
+     * been configured for the app-layer attribute.
+     * See {@link org.jasig.services.persondir.support.jdbc.AbstractJdbcPersonAttributeDao#setCaseInsensitiveDataAttributes(java.util.Map)}</p>
+     *
+     * @param queryBuilder
+     * @param queryAttribute
+     * @param dataAttribute
+     * @param queryValues
+     * @return
+     */
+    protected QB appendCanonicalizedAttributeToQuery(QB queryBuilder, String queryAttribute, String dataAttribute, List<Object> queryValues) {
+        // All logging messages were previously in generateQuery() and were
+        // copy/pasted verbatim
+        final List<Object> canonicalizedQueryValues = this.canonicalizeAttribute(queryAttribute, queryValues, caseInsensitiveQueryAttributes);
+        if ( dataAttribute == null ) {
+            // preserved from historical versions which just pass queryValues through without any association to a dataAttribute,
+            // and a slightly different log message
+            if (this.logger.isDebugEnabled()) {
+                this.logger.debug("Adding attribute '" + queryAttribute + "' with value '" + queryValues + "' to query builder '" + queryBuilder + "'");
+            }
+            return appendAttributeToQuery(queryBuilder, dataAttribute, canonicalizedQueryValues);
+        }
+        if (this.logger.isDebugEnabled()) {
+            this.logger.debug("Adding attribute '" + dataAttribute + "' with value '" + queryValues + "' to query builder '" + queryBuilder + "'");
+        }
+        return appendAttributeToQuery(queryBuilder, dataAttribute, canonicalizedQueryValues);
+    }
+
+    /**
      * Append the attribute and value to the queryBuilder.
      * 
      * @param queryBuilder The sub-class specific query builder object
@@ -272,10 +327,10 @@ public abstract class AbstractQueryPersonAttributeDao<QB> extends AbstractDefaul
     
     /**
      * Generates a query using the queryBuilder object passed by the subclass. Attribute/Value pairs are added to the
-     * queryBuilder by calling {@link #appendAttributeToQuery(Object, String, String)}. Attributes are only added if
+     * queryBuilder by calling {@link #appendCanonicalizedAttributeToQuery(Object, String, String, java.util.List)} which calls
+     * {@link #appendAttributeToQuery(Object, String, java.util.List)}. Attributes are only added if
      * there is an attributed mapped in the queryAttributeMapping.
-     * 
-     * @param queryBuilder The sub-class specific object to pass to {@link #appendAttributeToQuery(Object, String, String)} when building the query
+     *
      * @param query The query Map to populate the queryBuilder with.
      * @return The fully populated query builder.
      */
@@ -289,19 +344,11 @@ public abstract class AbstractQueryPersonAttributeDao<QB> extends AbstractDefaul
                 if (queryValues != null ) {
                     final Set<String> dataAttributes = queryAttrEntry.getValue();
                     if (dataAttributes == null) {
-                        if (this.logger.isDebugEnabled()) {
-                            this.logger.debug("Adding attribute '" + queryAttr + "' with value '" + queryValues + "' to query builder '" + queryBuilder + "'");
-                        }
-                        
-                        queryBuilder = this.appendAttributeToQuery(queryBuilder, null, queryValues); 
+                        queryBuilder = this.appendCanonicalizedAttributeToQuery(queryBuilder, queryAttr, null, queryValues);
                     }
                     else {
                         for (final String dataAttribute : dataAttributes) {
-                            if (this.logger.isDebugEnabled()) {
-                                this.logger.debug("Adding attribute '" + dataAttribute + "' with value '" + queryValues + "' to query builder '" + queryBuilder + "'");
-                            }
-                            
-                            queryBuilder = this.appendAttributeToQuery(queryBuilder, dataAttribute, queryValues); 
+                            queryBuilder = this.appendCanonicalizedAttributeToQuery(queryBuilder, queryAttr, dataAttribute, queryValues);
                         }
                     }
                 }
@@ -315,12 +362,8 @@ public abstract class AbstractQueryPersonAttributeDao<QB> extends AbstractDefaul
             for (final Map.Entry<String, List<Object>> queryAttrEntry : query.entrySet()) {
                 final String queryKey = queryAttrEntry.getKey();
                 final List<Object> queryValues = queryAttrEntry.getValue();
-                
-                if (this.logger.isDebugEnabled()) {
-                    this.logger.debug("Adding attribute '" + queryKey + "' with value '" + queryValues + "' to query builder '" + queryBuilder + "'");
-                }
-                
-                queryBuilder = this.appendAttributeToQuery(queryBuilder, queryKey, queryValues); 
+
+                queryBuilder = this.appendCanonicalizedAttributeToQuery(queryBuilder, queryKey, queryKey, queryValues);
             }
         }
         
@@ -344,7 +387,15 @@ public abstract class AbstractQueryPersonAttributeDao<QB> extends AbstractDefaul
         final Map<String, List<Object>> mappedAttributes;
         //If no mapping just use the attributes as-is
         if (this.resultAttributeMapping == null) {
-            mappedAttributes = personAttributes;
+            if (caseInsensitiveResultAttributes != null && !(caseInsensitiveResultAttributes.isEmpty())) {
+                mappedAttributes = new LinkedHashMap<String, List<Object>>();
+                for ( Map.Entry<String,List<Object>> attribute : personAttributes.entrySet() ) {
+                    String attributeName = attribute.getKey();
+                    mappedAttributes.put(attributeName, canonicalizeAttribute(attributeName, attribute.getValue(), caseInsensitiveResultAttributes));
+                }
+            } else {
+                mappedAttributes = personAttributes;
+            }
         }
         //Map the attribute names via the resultAttributeMapping
         else {
@@ -362,9 +413,11 @@ public abstract class AbstractQueryPersonAttributeDao<QB> extends AbstractDefaul
                         resultKeys = Collections.singleton(dataKey);
                     }
                     
-                    //Add the value to the mapped attributes for each mapped key
-                    final List<Object> value = personAttributes.get(dataKey);
+                    //Add the value to the mapped attributes for each mapped key,
+                    //possibly canonicalizing casing for each value
+                    List<Object> value = personAttributes.get(dataKey);
                     for (final String resultKey : resultKeys) {
+                        value = canonicalizeAttribute(resultKey, value, caseInsensitiveResultAttributes);
                         if (resultKey == null) {
                             //TODO is this possible?
                             mappedAttributes.put(dataKey, value);
@@ -381,16 +434,40 @@ public abstract class AbstractQueryPersonAttributeDao<QB> extends AbstractDefaul
         
         final String name = person.getName();
         if (name != null) {
-            newPerson = new NamedPersonImpl(name, mappedAttributes);
+            newPerson = new NamedPersonImpl(usernameCaseCanonicalizationMode.canonicalize(name), mappedAttributes);
         }
         else {
             final String userNameAttribute = this.getConfiguredUserNameAttribute();
-            newPerson = new AttributeNamedPersonImpl(userNameAttribute, mappedAttributes);
+            final IPersonAttributes tmpNewPerson = new AttributeNamedPersonImpl(userNameAttribute, mappedAttributes);
+            newPerson = new NamedPersonImpl(usernameCaseCanonicalizationMode.canonicalize(tmpNewPerson.getName()), mappedAttributes);
         }
         
         return newPerson;
     }
-    
+
+    protected List<Object> canonicalizeAttribute(String key, List<Object> value, Map<String, CaseCanonicalizationMode> config) {
+        if (value == null || value.isEmpty() || config == null || !(config.containsKey(key))) {
+            return value;
+        }
+        CaseCanonicalizationMode canonicalizationMode = config.get(key);
+        if ( canonicalizationMode == null ) {
+            // Intentionally late binding of the default to
+            // avoid unexpected behavior if you wait to assign
+            // the default until after you've injected the list
+            // of case-insensitive fields
+            canonicalizationMode = defaultCaseCanonicalizationMode;
+        }
+        List<Object> canonicalizedValues = new ArrayList<Object>(value.size());
+        for ( Object origValue : value ) {
+            if ( origValue instanceof String ) {
+                canonicalizedValues.add(canonicalizationMode.canonicalize((String) origValue, caseCanonicalizationLocale));
+            } else {
+                canonicalizedValues.add(origValue);
+            }
+        }
+        return canonicalizedValues;
+    }
+
     /**
      * Indicates which attribute found by the subclass should be taken as the 
      * 'username' attribute.  (E.g. 'uid' or 'sAMAccountName')  NOTE:  Any two 
@@ -422,4 +499,197 @@ public abstract class AbstractQueryPersonAttributeDao<QB> extends AbstractDefaul
     protected boolean isUserNameAttributeConfigured() {
         return this.unmappedUsernameAttribute != null;
     }
+
+    /**
+     * @see #setCaseInsensitiveResultAttributes(java.util.Map)
+     *
+     * @return
+     */
+    public Map<String,CaseCanonicalizationMode> getCaseInsensitiveResultAttributes() {
+        return caseInsensitiveResultAttributes;
+    }
+
+    /**
+     * Keys are app-layer attributes, values are the casing canonicalization
+     * modes for each, as applied when mapping from data-layer to application
+     * attributes. {@code null} values treated as
+     * {@link #DEFAULT_CASE_CANONICALIZATION_MODE} unless that default mode is
+     * overridden with
+     * {@link #setDefaultCaseCanonicalizationMode(org.jasig.services.persondir.util.CaseCanonicalizationMode)}.
+     *
+     * <p>Most commonly used for canonicalizing attributes used as unique
+     * identifiers, usually username. In that case it's a good idea to
+     * set that configuration here as well as via
+     * {@link #setUsernameCaseCanonicalizationMode(org.jasig.services.persondir.util.CaseCanonicalizationMode)}
+     * to ensure you don't end up with different results from
+     * {@link org.jasig.services.persondir.IPersonAttributes#getName()} and
+     * {@link IPersonAttributes#getAttributeValue(String)}.</p>
+     *
+     * <p>This config is separate from {@link #setCaseInsensitiveQueryAttributes(java.util.Map)}
+     * because you may want to support case-insensitive searching on data
+     * layer attributes, but respond with attribute values which preserve
+     * the original data layer casing.</p>
+     *
+     * @param caseInsensitiveResultAttributes
+     */
+    public void setCaseInsensitiveResultAttributes(Map<String, CaseCanonicalizationMode> caseInsensitiveResultAttributes) {
+        this.caseInsensitiveResultAttributes = caseInsensitiveResultAttributes;
+    }
+
+    /**
+     * Configuration convenience same as passing the given {@code Set} as the
+     * keys in the {@link #setCaseInsensitiveResultAttributes(java.util.Map)}
+     * {@code Map} and implicitly accepting the default canonicalization mode
+     * for each. Note that this setter will not assign canonicalization modes,
+     * meaning that you needn't ensure
+     * {@link #setDefaultCaseCanonicalizationMode(org.jasig.services.persondir.util.CaseCanonicalizationMode)}
+     * has already been called.
+     *
+     * @param caseInsensitiveResultAttributes
+     */
+    public void setCaseInsensitiveResultAttributesAsCollection(Collection<String> caseInsensitiveResultAttributes) {
+        if (caseInsensitiveResultAttributes == null || caseInsensitiveResultAttributes.isEmpty()) {
+            setCaseInsensitiveResultAttributes(null);
+        } else {
+            Map<String, CaseCanonicalizationMode> asMap = new HashMap<String, CaseCanonicalizationMode>();
+            for ( String attrib : caseInsensitiveResultAttributes ) {
+                asMap.put(attrib, null);
+            }
+            setCaseInsensitiveResultAttributes(asMap);
+        }
+    }
+
+    /**
+     * Configuration convenience same as passing the given {@code Set} as the
+     * keys in the {@link #setCaseInsensitiveQueryAttributes(java.util.Map)}
+     * {@code Map} and implicitly accepting the default canonicalization mode
+     * for each. Note that this setter will not assign canonicalization modes,
+     * meaning that you needn't ensure
+     * {@link #setDefaultCaseCanonicalizationMode(org.jasig.services.persondir.util.CaseCanonicalizationMode)}
+     * has already been called.
+     *
+     * @param caseInsensitiveQueryAttributes
+     */
+    public void setCaseInsensitiveQueryAttributesAsCollection(Collection<String> caseInsensitiveQueryAttributes) {
+        if (caseInsensitiveQueryAttributes == null || caseInsensitiveQueryAttributes.isEmpty()) {
+            setCaseInsensitiveQueryAttributes(null);
+        } else {
+            Map<String, CaseCanonicalizationMode> asMap = new HashMap<String, CaseCanonicalizationMode>();
+            for ( String attrib : caseInsensitiveQueryAttributes ) {
+                asMap.put(attrib, null);
+            }
+            setCaseInsensitiveQueryAttributes(asMap);
+        }
+    }
+
+    /**
+     * Keys are app-layer attributes, values are the casing canonicalization
+     * modes for each, as applied when mapping from an application layer
+     * query to a data layer query. {@code null} values treated as
+     * {@link #DEFAULT_CASE_CANONICALIZATION_MODE} unless that default mode is
+     * overridden with
+     * {@link #setDefaultCaseCanonicalizationMode(org.jasig.services.persondir.util.CaseCanonicalizationMode)}.
+     *
+     * <p>Use this for any attribute for which you'd like to support
+     * case-insensitive search and where the underlying data layer is
+     * case-sensitive. Of course, if the data layer does not store these
+     * attributes in the canonical casing, the data layer itself would also need
+     * to be canonicalized in a subclass-specific fashion. For example, see
+     * {@link org.jasig.services.persondir.support.jdbc.AbstractJdbcPersonAttributeDao#setCaseInsensitiveDataAttributes(java.util.Map)}.</p>
+     *
+     * <p>This config is separate from {@link #setCaseInsensitiveResultAttributes(java.util.Map)}
+     * because you may want to support case-insensitive searching on data
+     * layer attributes, but respond with attribute values which preserve
+     * the original data layer casing.</p>
+     *
+     * @param caseInsensitiveQueryAttributes
+     */
+    public void setCaseInsensitiveQueryAttributes(Map<String, CaseCanonicalizationMode> caseInsensitiveQueryAttributes) {
+        this.caseInsensitiveQueryAttributes = caseInsensitiveQueryAttributes;
+    }
+
+    /**
+     * @see #setCaseInsensitiveQueryAttributes(java.util.Map)
+     * @return
+     */
+    public Map<String, CaseCanonicalizationMode> getCaseInsensitiveQueryAttributes() {
+        return caseInsensitiveQueryAttributes;
+    }
+
+    /**
+     * Assign the {@link Locale} in which all casing canonicaliztions will occur.
+     * A {@code null} will be treated as {@link java.util.Locale#getDefault()}.
+     *
+     * @param caseCanonicalizationLocale
+     */
+    public void setCaseCanonicalizationLocale(Locale caseCanonicalizationLocale) {
+        if ( caseCanonicalizationLocale == null ) {
+            this.caseCanonicalizationLocale = Locale.getDefault();
+        } else {
+            this.caseCanonicalizationLocale = caseCanonicalizationLocale;
+        }
+    }
+
+    public Locale getCaseCanonicalizationLocale() {
+        return caseCanonicalizationLocale;
+    }
+
+    /**
+     * Override the default {@link CaseCanonicalizationMode}
+     * ({@link #DEFAULT_CASE_CANONICALIZATION_MODE}). Cannot be unset. A
+     * {@link null} will have the same effect as reverting to the default.
+     *
+     * @param defaultCaseCanonicalizationMode
+     */
+    public void setDefaultCaseCanonicalizationMode(CaseCanonicalizationMode defaultCaseCanonicalizationMode) {
+        if ( defaultCaseCanonicalizationMode == null ) {
+            this.defaultCaseCanonicalizationMode = DEFAULT_CASE_CANONICALIZATION_MODE;
+        } else {
+            this.defaultCaseCanonicalizationMode = defaultCaseCanonicalizationMode;
+        }
+    }
+
+    public CaseCanonicalizationMode getDefaultCaseCanonicalizationMode() {
+        return defaultCaseCanonicalizationMode;
+    }
+
+    /**
+     * Username canonicalization is a special case because
+     * {@link #mapPersonAttributes(org.jasig.services.persondir.IPersonAttributes)}
+     * doesn't know where it came from. It might have come from a data layer
+     * attribute. Or it might have been derived from the original query itself.
+     * There is no general way to query the {@link IPersonAttributes} to
+     * determine exactly what happened.
+     *
+     * <p>If you need to guarantee case-insensitive usernames
+     * <em>in {@link org.jasig.services.persondir.IPersonAttributes#getName()}</em>,
+     * set this property to the same mode that you set for your app-layer
+     * username attribute(s) via
+     * {@link #setCaseInsensitiveResultAttributes(java.util.Map)}.</p>
+     *
+     * <p>Otherwise, leave this property alone and no attempt will be made
+     * to canonicalize the value returned from
+     * {@link org.jasig.services.persondir.IPersonAttributes#getName()}</p>
+     *
+     * <p>That default behavior is consistent with the legacy behavior of
+     * being case sensitive w/r/t usernames.</p>
+     *
+     * @param usernameCaseCanonicalizationMode
+     */
+    public void setUsernameCaseCanonicalizationMode(CaseCanonicalizationMode usernameCaseCanonicalizationMode) {
+        if ( usernameCaseCanonicalizationMode == null ) {
+            this.usernameCaseCanonicalizationMode = DEFAULT_USERNAME_CASE_CANONICALIZATION_MODE;
+        } else {
+            this.usernameCaseCanonicalizationMode = usernameCaseCanonicalizationMode;
+        }
+    }
+
+    /**
+     * @see #setUsernameCaseCanonicalizationMode(org.jasig.services.persondir.util.CaseCanonicalizationMode)
+     * @return
+     */
+    public CaseCanonicalizationMode getUsernameCaseCanonicalizationMode() {
+        return this.usernameCaseCanonicalizationMode;
+    }
+
 }

--- a/person-directory-impl/src/main/java/org/jasig/services/persondir/support/AdditionalDescriptorsPersonAttributeDao.java
+++ b/person-directory-impl/src/main/java/org/jasig/services/persondir/support/AdditionalDescriptorsPersonAttributeDao.java
@@ -21,10 +21,12 @@ package org.jasig.services.persondir.support;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
 import org.jasig.services.persondir.IPersonAttributes;
+import org.jasig.services.persondir.util.CaseCanonicalizationMode;
 import org.springframework.beans.factory.annotation.Required;
 
 /**
@@ -63,6 +65,8 @@ public class AdditionalDescriptorsPersonAttributeDao extends AbstractDefaultAttr
     // Instance Members.
     private IPersonAttributes descriptors;
     private ICurrentUserProvider currentUserProvider;
+    private CaseCanonicalizationMode usernameCaseCanonicalizationMode = AbstractQueryPersonAttributeDao.DEFAULT_USERNAME_CASE_CANONICALIZATION_MODE;
+    private Locale usernameCaseCanonicalizationLocale = Locale.getDefault();
     
     /*
      * Public API.
@@ -121,7 +125,7 @@ public class AdditionalDescriptorsPersonAttributeDao extends AbstractDefaultAttr
         }
         
         final IUsernameAttributeProvider usernameAttributeProvider = super.getUsernameAttributeProvider();
-        final String uid = usernameAttributeProvider.getUsernameFromQuery(query);
+        String uid = usernameAttributeProvider.getUsernameFromQuery(query);
         if (uid == null) {
             if (this.logger.isDebugEnabled()) {
                 this.logger.debug("No username attribute found in query, returning null");
@@ -129,7 +133,7 @@ public class AdditionalDescriptorsPersonAttributeDao extends AbstractDefaultAttr
             
             return null;
         }
-
+        uid = usernameCaseCanonicalizationMode.canonicalize(uid, usernameCaseCanonicalizationLocale);
         
         String targetName = this.descriptors.getName();
         if (targetName == null) {
@@ -142,7 +146,8 @@ public class AdditionalDescriptorsPersonAttributeDao extends AbstractDefaultAttr
                 return null;
             }
         }
-        
+
+        targetName = usernameCaseCanonicalizationMode.canonicalize(targetName, usernameCaseCanonicalizationLocale);
         if (uid.equals(targetName)) {
             if (this.logger.isDebugEnabled()) {
                 this.logger.debug("Adding additional descriptors " + this.descriptors);
@@ -161,6 +166,30 @@ public class AdditionalDescriptorsPersonAttributeDao extends AbstractDefaultAttr
      */
     public Set<String> getPossibleUserAttributeNames() {
         return null;
+    }
+
+    public CaseCanonicalizationMode getUsernameCaseCanonicalizationMode() {
+        return usernameCaseCanonicalizationMode;
+    }
+
+    public void setUsernameCaseCanonicalizationMode(CaseCanonicalizationMode usernameCaseCanonicalizationMode) {
+        if ( usernameCaseCanonicalizationMode == null ) {
+            this.usernameCaseCanonicalizationMode = AbstractQueryPersonAttributeDao.DEFAULT_USERNAME_CASE_CANONICALIZATION_MODE;
+        } else {
+            this.usernameCaseCanonicalizationMode = usernameCaseCanonicalizationMode;
+        }
+    }
+
+    public Locale getUsernameCaseCanonicalizationLocale() {
+        return usernameCaseCanonicalizationLocale;
+    }
+
+    public void setUsernameCaseCanonicalizationLocale(Locale usernameCaseCanonicalizationLocale) {
+        if ( usernameCaseCanonicalizationLocale == null ) {
+            this.usernameCaseCanonicalizationLocale = Locale.getDefault();
+        } else {
+            this.usernameCaseCanonicalizationLocale = usernameCaseCanonicalizationLocale;
+        }
     }
 
 }

--- a/person-directory-impl/src/main/java/org/jasig/services/persondir/util/CaseCanonicalizationMode.java
+++ b/person-directory-impl/src/main/java/org/jasig/services/persondir/util/CaseCanonicalizationMode.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jasig.services.persondir.util;
+
+
+import java.util.Locale;
+
+import org.apache.commons.lang.StringUtils;
+
+public enum CaseCanonicalizationMode {
+
+    LOWER {
+        @Override
+        public String canonicalize(String value) {
+            return StringUtils.lowerCase(value);
+        }
+
+        @Override
+        public String canonicalize(String value, Locale locale) {
+            return StringUtils.lowerCase(value, locale);
+        }
+    },
+    UPPER {
+        @Override
+        public String canonicalize(String value) {
+            return StringUtils.upperCase(value);
+        }
+
+        @Override
+        public String canonicalize(String value, Locale locale) {
+            return StringUtils.upperCase(value, locale);
+        }
+    },
+    NONE {
+        @Override
+        public String canonicalize(String value) {
+            return value;
+        }
+
+        @Override
+        public String canonicalize(String value, Locale locale) {
+            return value;
+        }
+    };
+
+    public abstract String canonicalize(String value);
+    public abstract String canonicalize(String value, Locale locale);
+}

--- a/person-directory-impl/src/test/java/org/jasig/services/persondir/support/AbstractQueryPersonAttributeDaoTest.java
+++ b/person-directory-impl/src/test/java/org/jasig/services/persondir/support/AbstractQueryPersonAttributeDaoTest.java
@@ -19,17 +19,23 @@
 
 package org.jasig.services.persondir.support;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import junit.framework.TestCase;
 
 import org.jasig.services.persondir.IPersonAttributes;
+import org.jasig.services.persondir.util.CaseCanonicalizationMode;
+import org.jasig.services.persondir.util.Util;
 
 /**
  * @author Eric Dalquist 
@@ -98,6 +104,203 @@ public class AbstractQueryPersonAttributeDaoTest extends TestCase {
         
         //Do asList for an easy comparison
         assertEquals(Arrays.asList(expectedArgs), args);
+    }
+
+    public void testMapPersonAttributes_AsIs() {
+        final Map<String, List<Object>> storedAttrs = new HashMap<String, List<Object>>();
+        storedAttrs.put("username", Util.list("edalquist"));
+        storedAttrs.put("name.first", Util.list("eric"));
+        storedAttrs.put("name.last", Util.list("dalquist"));
+
+        final InMemoryAbstractQueryPersonAttributeDao dao = new InMemoryAbstractQueryPersonAttributeDao(storedAttrs);
+
+        final Map<String, List<Object>> seed = new HashMap<String, List<Object>>();
+        seed.put("username", Collections.singletonList((Object)"edalquist"));
+
+        final Set<IPersonAttributes> allResults = dao.getPeopleWithMultivaluedAttributes(seed);
+
+        assertEquals(1, allResults.size());
+        IPersonAttributes result = allResults.iterator().next();
+        // By default should just echo attribs from data layer as-is
+        assertEquals("edalquist", result.getName());
+        assertEquals(Util.genList("edalquist"), result.getAttributeValues("username"));
+        assertEquals(Util.genList("eric"), result.getAttributeValues("name.first"));
+        assertEquals(Util.genList("dalquist"), result.getAttributeValues("name.last"));
+    }
+
+    public void testMapPersonAttributes_Mapped() {
+        final Map<String, List<Object>> storedAttrs = new HashMap<String, List<Object>>();
+        storedAttrs.put("username", Util.list("edalquist"));
+        storedAttrs.put("name.first", Util.list("eric"));
+        storedAttrs.put("name.last", Util.list("dalquist"));
+
+        final InMemoryAbstractQueryPersonAttributeDao dao = new InMemoryAbstractQueryPersonAttributeDao(storedAttrs);
+
+        final Map<String, String> resultAttributeMappings = new LinkedHashMap<String, String>();
+        resultAttributeMappings.put("name.first", "fname");
+        resultAttributeMappings.put("name.last", "lname");
+        dao.setResultAttributeMapping(resultAttributeMappings);
+
+        final Map<String, List<Object>> seed = new HashMap<String, List<Object>>();
+        seed.put("username", Collections.singletonList((Object)"edalquist"));
+
+        final Set<IPersonAttributes> allResults = dao.getPeopleWithMultivaluedAttributes(seed);
+
+        assertEquals(1, allResults.size());
+        IPersonAttributes result = allResults.iterator().next();
+        assertEquals("edalquist", result.getName());
+        // Don't actually get a username attribute in this case because it's
+        // not in the result attribute mappings. But it *is* successfully mapped
+        // into the special "name" property on the IPersonAttributes as asserted
+        // above
+        assertEquals(Util.genList("eric"), result.getAttributeValues("fname"));
+        assertEquals(Util.genList("dalquist"), result.getAttributeValues("lname"));
+    }
+
+    public void testMapPersonAttributes_CaseInsensitive() {
+        final Map<String, List<Object>> storedAttrs = new HashMap<String, List<Object>>();
+        storedAttrs.put("username", Util.list("edalquist"));
+        storedAttrs.put("name.first", Util.list("eric"));
+        storedAttrs.put("name.last", Util.list("dalquist"));
+
+        final InMemoryAbstractQueryPersonAttributeDao dao = new InMemoryAbstractQueryPersonAttributeDao(storedAttrs);
+        final Map<String, CaseCanonicalizationMode> caseInsensitiveAttributes = new HashMap<String, CaseCanonicalizationMode>();
+        caseInsensitiveAttributes.put("name.first", CaseCanonicalizationMode.UPPER);
+        dao.setCaseInsensitiveResultAttributes(caseInsensitiveAttributes);
+
+        final Map<String, List<Object>> seed = new HashMap<String, List<Object>>();
+        seed.put("username", Collections.singletonList((Object)"edalquist"));
+
+        final Set<IPersonAttributes> allResults = dao.getPeopleWithMultivaluedAttributes(seed);
+
+        assertEquals(1, allResults.size());
+        IPersonAttributes result = allResults.iterator().next();
+        // By default should just echo attribs from data layer as-is
+        assertEquals("edalquist", result.getName());
+        assertEquals(Util.genList("edalquist"), result.getAttributeValues("username"));
+        assertEquals(Util.genList("ERIC"), result.getAttributeValues("name.first"));
+        assertEquals(Util.genList("dalquist"), result.getAttributeValues("name.last"));
+    }
+
+    public void testMapPersonAttributes_MappedCaseInsensitive() {
+        final Map<String, List<Object>> storedAttrs = new HashMap<String, List<Object>>();
+        storedAttrs.put("username", Util.list("edalquist"));
+        storedAttrs.put("name.first", Util.list("eric"));
+        storedAttrs.put("name.last", Util.list("dalquist"));
+
+        final InMemoryAbstractQueryPersonAttributeDao dao = new InMemoryAbstractQueryPersonAttributeDao(storedAttrs);
+        final Map<String, CaseCanonicalizationMode> caseInsensitiveAttributes = new HashMap<String, CaseCanonicalizationMode>();
+        caseInsensitiveAttributes.put("fname", CaseCanonicalizationMode.UPPER);
+        dao.setCaseInsensitiveResultAttributes(caseInsensitiveAttributes);
+
+        final Map<String, String> resultAttributeMappings = new LinkedHashMap<String, String>();
+        resultAttributeMappings.put("name.first", "fname");
+        resultAttributeMappings.put("name.last", "lname");
+        dao.setResultAttributeMapping(resultAttributeMappings);
+
+        final Map<String, List<Object>> seed = new HashMap<String, List<Object>>();
+        seed.put("username", Collections.singletonList((Object)"edalquist"));
+
+        final Set<IPersonAttributes> allResults = dao.getPeopleWithMultivaluedAttributes(seed);
+
+        assertEquals(1, allResults.size());
+        IPersonAttributes result = allResults.iterator().next();
+        assertEquals("edalquist", result.getName());
+        // Don't actually get a username attribute in this case because it's
+        // not in the result attribute mappings. But it *is* successfully mapped
+        // into the special "name" property on the IPersonAttributes as asserted
+        // above
+        assertEquals(Util.genList("ERIC"), result.getAttributeValues("fname"));
+        assertEquals(Util.genList("dalquist"), result.getAttributeValues("lname"));
+    }
+
+    public void testMapPersonAttributes_CaseInsensitiveDefaultCanonicalization() {
+        final Map<String, List<Object>> storedAttrs = new HashMap<String, List<Object>>();
+        storedAttrs.put("username", Util.list("EDALQUIST"));
+        storedAttrs.put("name.first", Util.list("ERIC"));
+        storedAttrs.put("name.last", Util.list("dalquist"));
+
+        final InMemoryAbstractQueryPersonAttributeDao dao = new InMemoryAbstractQueryPersonAttributeDao(storedAttrs);
+        // Not setting the CaseCanonicalizationMode here nor with an explicit
+        // setter
+        final Collection<String> caseInsensitiveAttributes = new HashSet<String>();
+        caseInsensitiveAttributes.add("username");
+        caseInsensitiveAttributes.add("name.first");
+        dao.setCaseInsensitiveResultAttributesAsCollection(caseInsensitiveAttributes);
+
+        // Without this the username *attribute* will be canonicalized correctly
+        // but the special username ("name", actually) *property* on
+        // IPersonAttributes won't be. See test below
+        dao.setUsernameCaseCanonicalizationMode(CaseCanonicalizationMode.LOWER);
+
+        final Map<String, List<Object>> seed = new HashMap<String, List<Object>>();
+        seed.put("username", Collections.singletonList((Object)"edalquist"));
+
+        final Set<IPersonAttributes> allResults = dao.getPeopleWithMultivaluedAttributes(seed);
+
+        assertEquals(1, allResults.size());
+        IPersonAttributes result = allResults.iterator().next();
+        // By default should just echo attribs from data layer as-is
+        assertEquals("edalquist", result.getName());
+        assertEquals(Util.genList("edalquist"), result.getAttributeValues("username"));
+        assertEquals(Util.genList("eric"), result.getAttributeValues("name.first"));
+        assertEquals(Util.genList("dalquist"), result.getAttributeValues("name.last"));
+    }
+
+    public void testMapPersonAttributes_IndependentUsernameCanonicalization() {
+        final Map<String, List<Object>> storedAttrs = new HashMap<String, List<Object>>();
+        storedAttrs.put("username", Util.list("EDALQUIST"));
+        storedAttrs.put("name.first", Util.list("ERIC"));
+        storedAttrs.put("name.last", Util.list("dalquist"));
+
+        final InMemoryAbstractQueryPersonAttributeDao dao = new InMemoryAbstractQueryPersonAttributeDao(storedAttrs);
+        // Not setting the CaseCanonicalizationMode here nor with an explicit
+        // setter
+        final Collection<String> caseInsensitiveAttributes = new HashSet<String>();
+        caseInsensitiveAttributes.add("username");
+        caseInsensitiveAttributes.add("name.first");
+        dao.setCaseInsensitiveResultAttributesAsCollection(caseInsensitiveAttributes);
+        // Intentionally *not* calling setUsernameCaseCanonicalizationMode()
+
+        final Map<String, List<Object>> seed = new HashMap<String, List<Object>>();
+        seed.put("username", Collections.singletonList((Object)"edalquist"));
+
+        final Set<IPersonAttributes> allResults = dao.getPeopleWithMultivaluedAttributes(seed);
+
+        assertEquals(1, allResults.size());
+        IPersonAttributes result = allResults.iterator().next();
+        // Username canonicalization always independent, for better or worse,
+        // of attribute canonicalization. See setUsernameCaseCanonicalizationMode()
+        assertEquals("EDALQUIST", result.getName());
+        assertEquals(Util.genList("edalquist"), result.getAttributeValues("username"));
+        assertEquals(Util.genList("eric"), result.getAttributeValues("name.first"));
+        assertEquals(Util.genList("dalquist"), result.getAttributeValues("name.last"));
+    }
+
+    private static class InMemoryAbstractQueryPersonAttributeDao extends AbstractQueryPersonAttributeDao<List<List<Object>>> {
+
+        private StubPersonAttributeDao storage;
+
+        InMemoryAbstractQueryPersonAttributeDao(Map<String, List<Object>> backingMap) {
+            storage = new StubPersonAttributeDao(backingMap);
+        }
+
+        @Override
+        protected List<IPersonAttributes> getPeopleForQuery(List<List<Object>> queryBuilder, String queryUserName) {
+            return new ArrayList(storage.getPeopleWithMultivaluedAttributes(new HashMap<String,List<Object>>()));
+        }
+
+        @Override
+        protected List<List<Object>> appendAttributeToQuery(List<List<Object>> queryBuilder, String dataAttribute, List<Object> queryValues) {
+            // copy/paste from TestQueryPersonAttributeDao. Don't really care what this does, though
+            if (queryBuilder == null) {
+                queryBuilder = new LinkedList<List<Object>>();
+            }
+
+            queryBuilder.add(queryValues);
+
+            return queryBuilder;
+        }
     }
 
     private class TestQueryPersonAttributeDao extends AbstractQueryPersonAttributeDao<List<List<Object>>> {

--- a/person-directory-impl/src/test/java/org/jasig/services/persondir/support/jdbc/AbstractCaseSensitivityJdbcPersonAttributeDaoTest.java
+++ b/person-directory-impl/src/test/java/org/jasig/services/persondir/support/jdbc/AbstractCaseSensitivityJdbcPersonAttributeDaoTest.java
@@ -1,0 +1,359 @@
+package org.jasig.services.persondir.support.jdbc;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import javax.sql.DataSource;
+
+import org.hsqldb.jdbcDriver;
+import org.jasig.services.persondir.IPersonAttributes;
+import org.jasig.services.persondir.support.AbstractDefaultQueryPersonAttributeDaoTest;
+import org.jasig.services.persondir.util.CaseCanonicalizationMode;
+import org.jasig.services.persondir.util.Util;
+import org.springframework.dao.DataAccessException;
+import org.springframework.jdbc.core.ConnectionCallback;
+import org.springframework.jdbc.datasource.SimpleDriverDataSource;
+
+import junit.framework.TestCase;
+
+/**
+ * Otherwise would be huge amounts of duplicated boilerplate for verifying
+ * both {@link SingleRowJdbcPersonAttributeDao} and
+ * {@link MultiRowJdbcPersonAttributeDao}.
+ *
+ * <p> Was no point, though, in extending
+ * {@link org.jasig.services.persondir.support.AbstractDefaultQueryPersonAttributeDaoTest}
+ * b/c those tests shouldn't necessarily behave the same way if we try to manipulate
+ * the case-sensitivity behavior of the DAO under test.</p>
+ */
+public abstract class AbstractCaseSensitivityJdbcPersonAttributeDaoTest extends AbstractDefaultQueryPersonAttributeDaoTest {
+
+    protected DataSource testDataSource;
+
+    protected abstract void setUpSchema(DataSource dataSource) throws SQLException;
+    protected abstract void tearDownSchema(DataSource dataSource) throws SQLException;
+    protected abstract AbstractJdbcPersonAttributeDao<Map<String, Object>> newDao(DataSource dataSource);
+    protected abstract void beforeNonUsernameQuery(AbstractJdbcPersonAttributeDao<Map<String, Object>> dao);
+
+    /**
+     * Some DAOs, e.g. {@link MultiRowJdbcPersonAttributeDao} cannot distinguish
+     * between mulitple data attributes for case canonicalization purposes,
+     * which invalidates some tests.
+     *
+     * @return
+     */
+    protected abstract boolean supportsPerDataAttributeCaseSensitivity();
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        this.testDataSource = new SimpleDriverDataSource(new jdbcDriver(), "jdbc:hsqldb:mem:adhommemds", "sa", "");
+        setUpSchema(testDataSource);
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        super.tearDown();
+        tearDownSchema(this.testDataSource);
+        this.testDataSource = null;
+    }
+
+    public void testCaseSensitiveUsernameQuery() {
+        final AbstractJdbcPersonAttributeDao<Map<String, Object>> impl = newDao(testDataSource);
+        impl.setUseAllQueryAttributes(false);
+        final Map<String, Object> columnsToAttributes = new LinkedHashMap<String, Object>();
+        columnsToAttributes.put("netid", "username");
+        impl.setResultAttributeMapping(columnsToAttributes);
+        final Map<String, Object> attributesToColumns = new LinkedHashMap<String, Object>();
+        attributesToColumns.put("username", "netid");
+        impl.setQueryAttributeMapping(attributesToColumns);
+
+        final IPersonAttributes wrongCaseResult = impl.getPerson("AWP9");
+        assertNull(wrongCaseResult);
+        final IPersonAttributes correctCaseResult = impl.getPerson("awp9");
+        assertNotNull(correctCaseResult);
+        assertEquals("awp9", correctCaseResult.getName());
+    }
+
+    public void testCaseSensitiveUsernameQuery_CanonicalizedUsernameResult() {
+        final AbstractJdbcPersonAttributeDao<Map<String, Object>> impl = newDao(testDataSource);
+        impl.setUseAllQueryAttributes(false);
+        final Map<String, Object> columnsToAttributes = new LinkedHashMap<String, Object>();
+        columnsToAttributes.put("netid", "username");
+        impl.setResultAttributeMapping(columnsToAttributes);
+        final Map<String, Object> attributesToColumns = new LinkedHashMap<String, Object>();
+        attributesToColumns.put("username", "netid");
+        impl.setQueryAttributeMapping(attributesToColumns);
+        // above was all boilerplate... here's the important stuff...
+        impl.setUsernameCaseCanonicalizationMode(CaseCanonicalizationMode.UPPER);
+
+        final IPersonAttributes wrongCaseResult = impl.getPerson("AWP9");
+        assertNull(wrongCaseResult);
+        final IPersonAttributes correctCaseResult = impl.getPerson("awp9");
+        assertNotNull(correctCaseResult);
+        assertEquals("AWP9", correctCaseResult.getName());
+    }
+
+    public void testCaseInsensitiveUsernameQuery() {
+        final AbstractJdbcPersonAttributeDao<Map<String, Object>> impl = newDao(testDataSource);
+        impl.setUseAllQueryAttributes(false);
+        final Map<String, Object> columnsToAttributes = new LinkedHashMap<String, Object>();
+        columnsToAttributes.put("netid", "username");
+        impl.setResultAttributeMapping(columnsToAttributes);
+        final Map<String, Object> attributesToColumns = new LinkedHashMap<String, Object>();
+        attributesToColumns.put("username", "netid");
+        impl.setQueryAttributeMapping(attributesToColumns);
+        // above was all boilerplate... here's the important stuff...
+        impl.setCaseInsensitiveQueryAttributesAsCollection(Util.genList("username"));
+
+        final IPersonAttributes wrongCaseResult = impl.getPerson("AWP9");
+        assertNotNull(wrongCaseResult);
+        assertEquals("AWP9", wrongCaseResult.getName());
+        // both casings should work
+        final IPersonAttributes correctCaseResult = impl.getPerson("awp9");
+        assertNotNull(correctCaseResult);
+        assertEquals("awp9", correctCaseResult.getName());
+
+    }
+
+    public void testCaseInsensitiveUsernameQuery_CanonicalizedUsernameResult() {
+        final AbstractJdbcPersonAttributeDao<Map<String, Object>> impl = newDao(testDataSource);
+        impl.setUseAllQueryAttributes(false);
+        final Map<String, Object> columnsToAttributes = new LinkedHashMap<String, Object>();
+        columnsToAttributes.put("netid", "username");
+        impl.setResultAttributeMapping(columnsToAttributes);
+        final Map<String, Object> attributesToColumns = new LinkedHashMap<String, Object>();
+        attributesToColumns.put("username", "netid");
+        impl.setQueryAttributeMapping(attributesToColumns);
+        // above was all boilerplate... here's the important stuff...
+        impl.setCaseInsensitiveQueryAttributesAsCollection(Util.genList("username"));
+
+        // username is a weird edge case... here you'd normally get the
+        // casing from the value passed in to getPerson(); we're just proving
+        // it can be coerced to an arbitrary casing in the mapped result.
+        impl.setUsernameCaseCanonicalizationMode(CaseCanonicalizationMode.LOWER);
+        final IPersonAttributes wrongCaseResult1 = impl.getPerson("AWP9");
+        assertNotNull(wrongCaseResult1);
+        assertEquals("awp9", wrongCaseResult1.getName());
+
+        // and now show we can go the other way too
+        impl.setUsernameCaseCanonicalizationMode(CaseCanonicalizationMode.UPPER);
+        final IPersonAttributes wrongCaseResult2 = impl.getPerson("AwP9");
+        assertNotNull(wrongCaseResult2);
+        assertEquals("AWP9", wrongCaseResult2.getName());
+
+    }
+
+    public void testCaseSensitiveNonUsernameAttributeQuery() {
+        final AbstractJdbcPersonAttributeDao<Map<String, Object>> impl = newDao(testDataSource);
+        impl.setUseAllQueryAttributes(false);
+        final Map<String, Object> columnsToAttributes = new LinkedHashMap<String, Object>();
+        columnsToAttributes.put("netid", "username");
+        columnsToAttributes.put("name", "firstName");
+        impl.setResultAttributeMapping(columnsToAttributes);
+        final Map<String, Object> attributesToColumns = new LinkedHashMap<String, Object>();
+        attributesToColumns.put("username", "netid");
+        attributesToColumns.put("firstName", "name");
+        impl.setQueryAttributeMapping(attributesToColumns);
+        beforeNonUsernameQuery(impl);
+
+        Map<String,Object> wrongCase = new LinkedHashMap<String, Object>();
+        wrongCase.put("firstName", "ANDREW");
+        final Set<IPersonAttributes> wrongCaseResult = impl.getPeople(wrongCase);
+        assertEquals(0, wrongCaseResult.size());
+
+        Map<String,Object> correctCase = new LinkedHashMap<String, Object>();
+        correctCase.put("firstName", "Andrew");
+        final Set<IPersonAttributes> correctCaseResult = impl.getPeople(correctCase);
+        assertEquals(2, correctCaseResult.size());
+        Iterator<IPersonAttributes> correctCaseResultIterator = correctCaseResult.iterator();
+        IPersonAttributes currentResult = correctCaseResultIterator.next();
+        assertEquals("awp9", currentResult.getName());
+        // make sure it preserved data-layer casing
+        assertEquals("Andrew", currentResult.getAttributeValue("firstName"));
+        currentResult = correctCaseResultIterator.next();
+        assertEquals("atest", currentResult.getName());
+        // make sure it preserved data-layer casing
+        assertEquals("Andrew", currentResult.getAttributeValue("firstName"));
+    }
+
+    public void testCaseSensitiveNonUsernameAttributeQuery_CanonicalizedResult() {
+        final AbstractJdbcPersonAttributeDao<Map<String, Object>> impl = newDao(testDataSource);
+        impl.setUseAllQueryAttributes(false);
+        final Map<String, Object> columnsToAttributes = new LinkedHashMap<String, Object>();
+        columnsToAttributes.put("netid", "username");
+        columnsToAttributes.put("name", "firstName");
+        impl.setResultAttributeMapping(columnsToAttributes);
+        final Map<String, Object> attributesToColumns = new LinkedHashMap<String, Object>();
+        attributesToColumns.put("username", "netid");
+        attributesToColumns.put("firstName", "name");
+        impl.setQueryAttributeMapping(attributesToColumns);
+        impl.setCaseInsensitiveResultAttributesAsCollection(Util.genList("firstName"));
+        beforeNonUsernameQuery(impl);
+
+        Map<String,Object> wrongCase = new LinkedHashMap<String, Object>();
+        wrongCase.put("firstName", "ANDREW");
+        final Set<IPersonAttributes> wrongCaseResult = impl.getPeople(wrongCase);
+        assertEquals(0, wrongCaseResult.size());
+
+        Map<String,Object> correctCase = new LinkedHashMap<String, Object>();
+        correctCase.put("firstName", "Andrew");
+        final Set<IPersonAttributes> correctCaseResult = impl.getPeople(correctCase);
+        assertEquals(2, correctCaseResult.size());
+        Iterator<IPersonAttributes> correctCaseResultIterator = correctCaseResult.iterator();
+        IPersonAttributes currentResult = correctCaseResultIterator.next();
+        assertEquals("awp9", currentResult.getName());
+        // make sure it overrode data-layer casing
+        assertEquals("andrew", currentResult.getAttributeValue("firstName"));
+        currentResult = correctCaseResultIterator.next();
+        assertEquals("atest", currentResult.getName());
+        // make sure it overrode data-layer casing
+        assertEquals("andrew", currentResult.getAttributeValue("firstName"));
+    }
+
+    public void testCaseInsensitiveNonUsernameAttributeQuery() {
+        final AbstractJdbcPersonAttributeDao<Map<String, Object>> impl = newDao(testDataSource);
+        impl.setUseAllQueryAttributes(false);
+        final Map<String, Object> columnsToAttributes = new LinkedHashMap<String, Object>();
+        columnsToAttributes.put("netid", "username");
+        columnsToAttributes.put("name", "firstName");
+        impl.setResultAttributeMapping(columnsToAttributes);
+        final Map<String, Object> attributesToColumns = new LinkedHashMap<String, Object>();
+        attributesToColumns.put("username", "netid");
+        attributesToColumns.put("firstName", "name");
+        impl.setQueryAttributeMapping(attributesToColumns);
+        // above was all boilerplate... here's the important stuff...
+        // intentionally not setting "name" in the
+        // caseInsensitiveResultAttributes to verify that we have the option
+        // of preserving data-layer casing when mapping values out, even if
+        // the original query on that field was case-insensitive
+        impl.setCaseInsensitiveQueryAttributesAsCollection(Util.genList("firstName"));
+        impl.setCaseInsensitiveDataAttributesAsCollection(Util.genList("name"));
+        beforeNonUsernameQuery(impl);
+
+        Map<String,Object> wrongCase = new LinkedHashMap<String, Object>();
+        wrongCase.put("firstName", "ANDREW");
+        final Set<IPersonAttributes> wrongCaseResult = impl.getPeople(wrongCase);
+        assertEquals(2, wrongCaseResult.size());
+        Iterator<IPersonAttributes> resultIterator = wrongCaseResult.iterator();
+        IPersonAttributes currentResult = resultIterator.next();
+        assertEquals("awp9", currentResult.getName());
+        // make sure it preserved data-layer casing
+        assertEquals("Andrew", currentResult.getAttributeValue("firstName"));
+        currentResult = resultIterator.next();
+        assertEquals("atest", currentResult.getName());
+        // make sure it preserved data-layer casing
+        assertEquals("Andrew", currentResult.getAttributeValue("firstName"));
+
+        Map<String,Object> correctCase = new LinkedHashMap<String, Object>();
+        correctCase.put("firstName", "Andrew");
+        final Set<IPersonAttributes> correctCaseResult = impl.getPeople(correctCase);
+        assertEquals(2, correctCaseResult.size());
+        resultIterator = correctCaseResult.iterator();
+        currentResult = resultIterator.next();
+        assertEquals("awp9", currentResult.getName());
+        // make sure it preserved data-layer casing
+        assertEquals("Andrew", currentResult.getAttributeValue("firstName"));
+        currentResult = resultIterator.next();
+        assertEquals("atest", currentResult.getName());
+        // make sure it preserved data-layer casing
+        assertEquals("Andrew", currentResult.getAttributeValue("firstName"));
+    }
+
+    public void testCaseInsensitiveNonUsernameAttributeQuery_CanonicalizedResult() {
+        final AbstractJdbcPersonAttributeDao<Map<String, Object>> impl = newDao(testDataSource);
+        impl.setUseAllQueryAttributes(false);
+        final Map<String, Object> columnsToAttributes = new LinkedHashMap<String, Object>();
+        columnsToAttributes.put("netid", "username");
+        columnsToAttributes.put("name", "firstName");
+        impl.setResultAttributeMapping(columnsToAttributes);
+        final Map<String, Object> attributesToColumns = new LinkedHashMap<String, Object>();
+        attributesToColumns.put("username", "netid");
+        attributesToColumns.put("firstName", "name");
+        impl.setQueryAttributeMapping(attributesToColumns);
+        // above was all boilerplate... here's the important stuff...
+        // (actually same as non-_CanonicalizedResult except we do configure
+        // a case-insensitive result query)
+        impl.setCaseInsensitiveQueryAttributesAsCollection(Util.genList("firstName"));
+        impl.setCaseInsensitiveDataAttributesAsCollection(Util.genList("name"));
+        impl.setCaseInsensitiveResultAttributesAsCollection(Util.genList("firstName"));
+        beforeNonUsernameQuery(impl);
+
+        Map<String,Object> wrongCase = new LinkedHashMap<String, Object>();
+        wrongCase.put("firstName", "ANDREW");
+        final Set<IPersonAttributes> wrongCaseResult = impl.getPeople(wrongCase);
+        assertEquals(2, wrongCaseResult.size());
+        Iterator<IPersonAttributes> resultIterator = wrongCaseResult.iterator();
+        IPersonAttributes currentResult = resultIterator.next();
+        assertEquals("awp9", currentResult.getName());
+        // make sure it overrode data-layer casing
+        assertEquals("andrew", currentResult.getAttributeValue("firstName"));
+        currentResult = resultIterator.next();
+        assertEquals("atest", currentResult.getName());
+        // make sure it overrode data-layer casing
+        assertEquals("andrew", currentResult.getAttributeValue("firstName"));
+
+        Map<String,Object> correctCase = new LinkedHashMap<String, Object>();
+        correctCase.put("firstName", "Andrew");
+        final Set<IPersonAttributes> correctCaseResult = impl.getPeople(correctCase);
+        assertEquals(2, correctCaseResult.size());
+        resultIterator = correctCaseResult.iterator();
+        currentResult = resultIterator.next();
+        assertEquals("awp9", currentResult.getName());
+        // make sure it overrode data-layer casing
+        assertEquals("andrew", currentResult.getAttributeValue("firstName"));
+        currentResult = resultIterator.next();
+        assertEquals("atest", currentResult.getName());
+        // make sure it overrode data-layer casing
+        assertEquals("andrew", currentResult.getAttributeValue("firstName"));
+    }
+
+    // Guards against a bug discovered in the original SSP-1668/PERSONDIR-74
+    // patch where setting any caseInsensitiveDataAttributes config would
+    // cause all data attributes to be canonicalized
+    public void testCaseSensitiveNonUsernameAttributeQuery_OtherCaseInsensitiveDataAttributes() {
+        if ( !(supportsPerDataAttributeCaseSensitivity()) ) {
+            // Some DAOs, e.g. MultiRowJdbcPersonAttributeDao cannot distinguish
+            // between mulitple data attributes for case canonicalization purposes.
+            return;
+        }
+        final AbstractJdbcPersonAttributeDao<Map<String, Object>> impl = newDao(testDataSource);
+        impl.setUseAllQueryAttributes(false);
+        final Map<String, Object> columnsToAttributes = new LinkedHashMap<String, Object>();
+        columnsToAttributes.put("netid", "username");
+        columnsToAttributes.put("name", "firstName");
+        columnsToAttributes.put("email", "emailAddr");
+        impl.setResultAttributeMapping(columnsToAttributes);
+        final Map<String, Object> attributesToColumns = new LinkedHashMap<String, Object>();
+        attributesToColumns.put("username", "netid");
+        attributesToColumns.put("firstName", "name");
+        attributesToColumns.put("emailAddr", "email");
+        impl.setQueryAttributeMapping(attributesToColumns);
+        impl.setCaseInsensitiveDataAttributesAsCollection(Util.genList("email"));
+        beforeNonUsernameQuery(impl);
+
+        Map<String,Object> wrongCase = new LinkedHashMap<String, Object>();
+        wrongCase.put("firstName", "ANDREW");
+        final Set<IPersonAttributes> wrongCaseResult = impl.getPeople(wrongCase);
+        assertEquals(0, wrongCaseResult.size());
+
+        Map<String,Object> correctCase = new LinkedHashMap<String, Object>();
+        correctCase.put("firstName", "Andrew");
+        final Set<IPersonAttributes> correctCaseResult = impl.getPeople(correctCase);
+        assertEquals(2, correctCaseResult.size());
+        Iterator<IPersonAttributes> correctCaseResultIterator = correctCaseResult.iterator();
+        IPersonAttributes currentResult = correctCaseResultIterator.next();
+        assertEquals("awp9", currentResult.getName());
+        // make sure it preserved data-layer casing
+        assertEquals("Andrew", currentResult.getAttributeValue("firstName"));
+        currentResult = correctCaseResultIterator.next();
+        assertEquals("atest", currentResult.getName());
+        // make sure it preserved data-layer casing
+        assertEquals("Andrew", currentResult.getAttributeValue("firstName"));
+    }
+
+
+}


### PR DESCRIPTION
Addresses [SSP-1668](https://issues.jasig.org/browse/SSP-1668) and [PERSONDIR-74](https://issues.jasig.org/browse/PERSONDIR-74).

In [the uportal-user thread that prompted those two tickets](http://jasig.275507.n4.nabble.com/Case-sensitive-username-tt4660475.html) I had
suggested a patch to `BaseAdditiveAttributeMerger` might do
the trick. Indeed it does work, sort of
(https://github.com/dmccallum/person-directory/tree/SSP-1668).
That patch is limited to username attributes and only addresses
_result_ attribute case-sensitivity (as opposed to also supporting
case-insensitive _query_ attributes, which is probably what one
expects if PD/uP were to claim to support case-insensitive
usernames/attributes). Also, because it only deals with
`IPersonAttributes#getName()`, you can end up with oddities
like that field's casing being canonicalized, but not the casing
of the actual attribute from which it was derived. This can lead
to a confusing user experience when browsing user attributes
in uPortal, for example. And the fact that this patch actually
changes attribute values was also a bit of a departure from the way 
I think `IAttributeMerger` impls have worked in the past, where
they've mostly been responsible for choosing from among or
collecting many attribute values, not so much changing the actual
values returned from DAOs.

So I ended up taking a different approach and moved the case-
sensitivity "down" into the DAO layer, which is the approach
represented by this pull request. It also generalizes the solution to
support all result, query, and data attributes, plus special username
handling. SSP is currently running this patch, along with a supporting
uPortal patch
(https://github.com/Jasig/uPortal/commit/1ef731e27a1eae8e413aa3bcc97433931eb462c6)
in its nightly build environment. 

Sample `personDirectoryContext.xml` config from that patch:

A bean for listing all app-layer username attributes:

``` xml
<util:set id="username-logical-attributes">
    <value>username</value>
    <value>uid</value>
    <value>username</value>
    <value>user.login.id</value>
    <value>schoolId</value>
</util:set>
```

An abstract bean for any DAO that needs to canonicalize
`IPersonAttributes.getName()` values:

``` xml
<bean abstract="true" id="usernameCanonicalizing">
  <property name="usernameCaseCanonicalizationMode" value="LOWER" />
</bean>
```

An abstract bean for a DAO that also canonicalizes username query
and result attributes:

``` xml
<bean abstract="true" parent="usernameCanonicalizing" id="logicalAttributeCanonicalizing">
    <property name="caseInsensitiveResultAttributesAsCollection" ref="username-logical-attributes" />
    <property name="caseInsensitiveQueryAttributesAsCollection" ref="username-logical-attributes" />
</bean>
```

Then `requestAttributesDao` extends `usernameCanonicalizing`. 
`uPortalAccountUserSource` and `uPortalJdbcUserSource` extend 
`logicalAttributeCanonicalizing`. `uPortalJdbcUserSource` also adds the
following to canonicalize in-database username values:

``` xml
<!-- Only need caseInsensitiveDataAttributesAsCollection if the
      underlying data is non-canonically cased -->
<property name="caseInsensitiveDataAttributesAsCollection">
    <set>
        <value>USER_NAME</value>
    </set>
</property>
```

This does seem to take care of both the search use case described in 
SSP-1668 as well as uP-local logins using a non-canonical username
casing. But I'm a bit concerned it might not address all permutations of
the latter. In particular, I'm not convinced the portlet user attributes are
being properly canonicalized. But that's a uPortal issue, not a PD issue.

This is obviously a very large patch and I expect you may want to sit on
it for a while while it soaks a bit in the SSP bathwaters.
##### Following is just the standard copy/paste from the original commit log:

Also some special handling for username case-sensitivity, reflecting
the existing special treatment of that property throughout PD.

Username case-insensitivity was the primary motivation for this patch,
but the solution was much more general.

All attribute values are still case-sensitive by default, preserving
legacy behavior.

Configure case-insenstivity on query attributes if you want searches
to be case-insensitive. If your underlying data layer is case
sensitive and stores values in non-canonical casings, you'll also
need to set corresponding data attribute case-insensitivity config.
Not all data layers will handle this equally well, though. If the
data layer does not support function-based indices you'll want to
prefer storing data in a canonical casing.

Configure case-insensitivity in result attributes if you want to
normalize in-application representation of certain attributes. This
is most useful for usernames.

Splitting query and result configuration in this way allows for
case-insensitive attribute search while preserving data-layer
attribute value casing. E.g. you may want case-insensitive search
on givenName but you don't want all those values converted to
lower case when returned to the application. (Note that uPortal's
JPA DAO (which is actually outside the PD DAO hierarchy) already
supported this for non-username attributes.)

Query and result attribute case-sensitivity is configurable for
subclasses of AbstractQueryPersonAttributeDao.

Data attribute case-sensitivity is configurable for subclasses of
AbstractJdbcPersonAttributeDao. This patch did not include direct
support for LdapPersonAttributeDao because the LDAP schema typically
specifies which attributes should be handled case-insensitively, thus
the data layer effectively solves the problem for us, assuming a
well-designed schema.

All case-sensitivity config is in terms of application- rather than
data-layer attribute names. This allows for configuration to be
consolidated, e.g. into one or more abstract parent beans, because
the sensitivity policy can be set once per application attribute
rather than once for every uniquely named data-layer attribute. It
also more accurately reflects the intent of the configuration, which
is to declare the global case-sensitivity assumptions the application
makes.
