### PR TITLE
Add engineName property to ScriptEnginePersonAttributeDao

### DIFF
--- a/person-directory-impl/src/test/java/org/apereo/services/persondir/support/ScriptEnginePersonAttributeDaoTest.java
+++ b/person-directory-impl/src/test/java/org/apereo/services/persondir/support/ScriptEnginePersonAttributeDaoTest.java
@@ -1,16 +1,31 @@
 package org.apereo.services.persondir.support;
 
+import org.apache.commons.io.IOUtils;
 import org.apereo.services.persondir.AbstractPersonAttributeDaoTest;
 import org.apereo.services.persondir.IPersonAttributeDao;
 import org.apereo.services.persondir.IPersonAttributes;
 import org.apereo.services.persondir.util.Util;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations = {"/annotationContext.xml"})
 public class ScriptEnginePersonAttributeDaoTest extends AbstractPersonAttributeDaoTest {
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
     private ScriptEnginePersonAttributeDao dao;
 
     public ScriptEnginePersonAttributeDaoTest() {
@@ -22,6 +37,7 @@ public class ScriptEnginePersonAttributeDaoTest extends AbstractPersonAttributeD
         return this.dao;
     }
 
+    @Test
     public void testGetAttributesWithJavascript() {
         this.dao.setScriptFile("SampleScriptedJavascriptPersonAttributeDao.js");
         final IPersonAttributes person = this.dao.getPerson("testuser");
@@ -30,6 +46,7 @@ public class ScriptEnginePersonAttributeDaoTest extends AbstractPersonAttributeD
         assertEquals(person.getAttributes().size(), 4);
     }
 
+    @Test
     public void testGetAttributesWithGroovy() {
         this.dao.setScriptFile("SampleScriptedGroovyPersonAttributeDao.groovy");
         final IPersonAttributes person = this.dao.getPerson("testuser");
@@ -38,6 +55,17 @@ public class ScriptEnginePersonAttributeDaoTest extends AbstractPersonAttributeD
         assertEquals(person.getAttributes().size(), 4);
     }
 
+    @Test
+    public void testGetAttributesWithGroovyString() throws IOException {
+        this.dao.setScriptFile(IOUtils.toString(applicationContext.getResource("file:./src/test/resources/SampleScriptedGroovyPersonAttributeDao.groovy").getInputStream(), StandardCharsets.UTF_8));
+        this.dao.setEngineName("groovy");
+        final IPersonAttributes person = this.dao.getPerson("testuser");
+        assertNotNull(person);
+        assertEquals(person.getName(), "testuser");
+        assertEquals(person.getAttributes().size(), 4);
+    }
+
+    @Test
     public void testGetMultiValuedAttributesWithGroovy() {
         this.dao.setScriptFile("SampleScriptedGroovyPersonAttributeDao.groovy");
         final Map<String, List<Object>> query = new LinkedHashMap<>();

--- a/person-directory-impl/src/test/resources/annotationContext.xml
+++ b/person-directory-impl/src/test/resources/annotationContext.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to Apereo under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Apereo licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:aop="http://www.springframework.org/schema/aop"
+       xmlns:tx="http://www.springframework.org/schema/tx"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="
+    http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+    http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+    http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd
+    http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd">
+
+    <context:annotation-config/>
+
+</beans>

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <toml.version>1.0.0</toml.version>
         <xerces.version>2.11.0</xerces.version>
         <jackson.version>2.8.5</jackson.version>
-        <commons-io.version>2.4</commons-io.version>
+        <commons-io.version>2.6</commons-io.version>
         <ldaptive.version>1.2.1</ldaptive.version>
         <apachehttpclient>4.5.3</apachehttpclient>
         


### PR DESCRIPTION
This supports the ability to pass contents of script rather than the filename.
Update commons-io version to match CAS (for use in unit test)

I will submit a pull request to CAS after this is merged. 