### PR TITLE
Compute engineName based on extension and all available engines

### DIFF
--- a/person-directory-impl/src/main/java/org/apereo/services/persondir/support/ScriptEnginePersonAttributeDao.java
+++ b/person-directory-impl/src/main/java/org/apereo/services/persondir/support/ScriptEnginePersonAttributeDao.java
@@ -1,14 +1,19 @@
 package org.apereo.services.persondir.support;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apereo.services.persondir.IPersonAttributes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.script.Invocable;
 import javax.script.ScriptEngine;
+import javax.script.ScriptEngineFactory;
 import javax.script.ScriptEngineManager;
 import java.io.File;
 import java.io.FileReader;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.StringReader;
@@ -47,7 +52,10 @@ import java.util.Set;
  * @author Misagh Moayyed
  */
 public class ScriptEnginePersonAttributeDao extends BasePersonAttributeDao {
+    private static final Logger logger = LoggerFactory.getLogger(ScriptEnginePersonAttributeDao.class);
     private String scriptFile;
+    public enum SCRIPT_TYPE {RESOURCE, FILE, CONTENTS}
+    private SCRIPT_TYPE scriptType;
     private String engineName;
     private boolean caseInsensitiveUsername = false;
     private final IUsernameAttributeProvider usernameAttributeProvider = new SimpleUsernameAttributeProvider();
@@ -56,16 +64,32 @@ public class ScriptEnginePersonAttributeDao extends BasePersonAttributeDao {
         return scriptFile;
     }
 
+    // Current unit tests re-use an instance of this DAO,
+    // this object would be better if engineName and scriptFile couldn't change
     public void setScriptFile(final String scriptFile) {
         this.scriptFile = scriptFile;
+        this.scriptType = determineScriptType(scriptFile);
+        if (scriptType != SCRIPT_TYPE.CONTENTS) {
+            // assume that if adjusting the file, engine name should also be re-calc'd
+            // if scriptType is CONTENTS then we can't determine engineName anyway
+            this.engineName = getScriptEngineName(scriptFile);
+        }
     }
 
     public String getEngineName() {
         return engineName;
     }
 
+    protected SCRIPT_TYPE getScriptType() {
+        return scriptType;
+    }
+
     public void setEngineName(final String engineName) {
         this.engineName = engineName;
+        final ScriptEngine engine = new ScriptEngineManager().getEngineByName(engineName);
+        if (engine == null) {
+            logger.warn("Specified engineName {} is not available in classpath.", engineName);
+        }
     }
 
     public boolean isCaseInsensitiveUsername() {
@@ -89,8 +113,8 @@ public class ScriptEnginePersonAttributeDao extends BasePersonAttributeDao {
      * If its the string version then engine name must be set using setter.
      */
     public ScriptEnginePersonAttributeDao(String scriptFile) {
-        this.scriptFile = scriptFile;
-        this.engineName = getEngineName();
+        setScriptFile(scriptFile);
+        this.engineName = getScriptEngineName(scriptFile);
     }
 
     /**
@@ -102,8 +126,8 @@ public class ScriptEnginePersonAttributeDao extends BasePersonAttributeDao {
      */
 
     public ScriptEnginePersonAttributeDao(String scriptFile, String engineName) {
-        this.scriptFile = scriptFile;
-        this.engineName = engineName;
+        setScriptFile(scriptFile);
+        setEngineName(engineName);
     }
 
     @Override
@@ -148,40 +172,53 @@ public class ScriptEnginePersonAttributeDao extends BasePersonAttributeDao {
     }
 
     private Map<String, Object> getScriptedAttributesFromFile(final String uid) throws Exception {
-        if (engineName == null) {
-            engineName = getScriptEngineName(this.scriptFile);
-            if (StringUtils.isBlank(engineName)) {
-                logger.warn("Unable to determine script engine, please set engineName property");
-                return new HashMap<>();
-            }
+
+        if (StringUtils.isBlank(scriptFile)) {
+            logger.warn("Script file or contents not set.");
+            return new HashMap<>();
         }
+
+        if (StringUtils.isBlank(engineName)) {
+            if (scriptType == SCRIPT_TYPE.CONTENTS) {
+                // don't log contents of script
+                logger.warn("Engine name not specified, not running script.");
+            } else {
+                logger.warn("Unable to determine engineName for script: {}, not running script", scriptFile);
+            }
+            return new HashMap<>();
+        }
+
         // ScriptEngineManager().getEngineByName(engineName) will throw NPE if engineName is null
         final ScriptEngine engine = new ScriptEngineManager().getEngineByName(engineName);
         if (engine == null) {
-            logger.warn("Script engine is not available for [{}]", engineName);
+            logger.warn("Script engine is not available in classpath for [{}]", engineName);
             return new HashMap<>();
         }
 
         logger.debug("Created script engine instance for [{}]", engineName);
         final Object[] args = {uid, logger};
 
-        final File theScriptFile = new File(this.scriptFile);
-        if (theScriptFile.exists()) {
-            logger.debug("Loading script from [{}]", theScriptFile);
-            engine.eval(new FileReader(theScriptFile));
-        } else {
-            boolean foundStream = false;
-            try (InputStream in = getClass().getClassLoader().getResourceAsStream(this.scriptFile)) {
-                if (in != null && in.markSupported() && in.available() > 0) {
-                    logger.debug("Loading script [{}] from classloader as a stream", theScriptFile);
-                    engine.eval(new InputStreamReader(in));
-                    foundStream = true;
+        switch (scriptType) {
+            case RESOURCE:
+                try (InputStream in = getClass().getClassLoader().getResourceAsStream(this.scriptFile)) {
+                    if (in != null && in.markSupported() && in.available() > 0) {
+                        logger.debug("Loading script [{}] from classloader as a stream", this.scriptFile);
+                        engine.eval(new InputStreamReader(in));
+                    }
                 }
-            }
-            if (!foundStream) {
-                logger.debug("Loading script [{}] in raw text format", theScriptFile);
+                break;
+            case FILE:
+                final File theScriptFile = new File(this.scriptFile);
+                logger.debug("Loading script from [{}]", theScriptFile);
+                engine.eval(new FileReader(theScriptFile));
+                break;
+            case CONTENTS:
+                logger.debug("Evaluating script contents [\n{}\n]", this.scriptFile);
                 engine.eval(new StringReader(this.scriptFile));
-            }
+                break;
+            default:
+                throw new IllegalStateException("Unsupported script type: " + scriptType);
+
         }
 
         logger.debug("Executing script's run method, with parameters [{}]", args);
@@ -191,6 +228,25 @@ public class ScriptEnginePersonAttributeDao extends BasePersonAttributeDao {
         logger.debug("Final set of attributes determined by the script are [{}]", personAttributesMap);
         return personAttributesMap;
     }
+
+    private SCRIPT_TYPE determineScriptType(String fileName) {
+        File f = new File(fileName);
+        if (f.exists() && f.isFile()) {
+            return SCRIPT_TYPE.FILE;
+        }
+
+        InputStream in = ScriptEnginePersonAttributeDao.class.getClassLoader().getResourceAsStream(fileName);
+        try {
+            if (in != null && in.markSupported() && in.available() > 0) {
+                return SCRIPT_TYPE.RESOURCE;
+            }
+        } catch (IOException e) {
+            logger.warn("Error checking if stream exists: {}",e.getMessage(),e);
+            return SCRIPT_TYPE.CONTENTS;
+        }
+        return SCRIPT_TYPE.CONTENTS;
+    }
+
 
     private static Map<String, List<Object>> stuffAttributesIntoListValues(final Map<String, Object> personAttributesMap) {
         final Map<String, List<Object>> personAttributes = new HashMap<>();
@@ -205,16 +261,30 @@ public class ScriptEnginePersonAttributeDao extends BasePersonAttributeDao {
         return personAttributes;
     }
 
+    /**
+     * This method is static is available as utility for users that are passing the contents of a script
+     * and want to set the engineName property based on a filename.
+     * @param filename
+     * @return
+     */
     public static String getScriptEngineName(String filename) {
-        String engineName = null;
-        if (filename.endsWith(".py")) {
-            engineName = "python";
-        } else if (filename.endsWith(".js")) {
-            engineName = "js";
-        } else if (filename.endsWith(".groovy")) {
-            engineName = "groovy";
+        String extension = FilenameUtils.getExtension(filename);
+        if (StringUtils.isBlank(extension)) {
+            logger.warn("Can't determine engine name based on filename without extension {}",filename);
+            return null;
         }
-        return engineName;
-
+        ScriptEngineManager manager = new ScriptEngineManager();
+        List<ScriptEngineFactory> engines = manager.getEngineFactories();
+        for (ScriptEngineFactory engineFactory : engines) {
+            List<String> extensions = engineFactory.getExtensions();
+            for (String supportedExt : extensions) {
+                if (extension.equals(supportedExt)) {
+                    // return first short name
+                    return engineFactory.getNames().get(0);
+                }
+            }
+        }
+        logger.warn("Can't determine engine name based on filename and available script engines {}",filename);
+        return null;
     }
 }

--- a/person-directory-impl/src/test/java/org/apereo/services/persondir/support/ScriptEnginePersonAttributeDaoTest.java
+++ b/person-directory-impl/src/test/java/org/apereo/services/persondir/support/ScriptEnginePersonAttributeDaoTest.java
@@ -72,7 +72,31 @@ public class ScriptEnginePersonAttributeDaoTest extends AbstractPersonAttributeD
         query.put("username", Util.list("testuser"));
         final Set<IPersonAttributes> personSet = this.dao.getPeopleWithMultivaluedAttributes(query);
         assertNotNull(personSet);
-        assertEquals(personSet.size(),1);
-        assertEquals(((IPersonAttributes)personSet.iterator().next()).getName(),"testuser");
+        assertEquals(personSet.size(), 1);
+        assertEquals(((IPersonAttributes) personSet.iterator().next()).getName(), "testuser");
+    }
+
+    @Test
+    public void testGetScriptEngineName() {
+        // test with an inline script, even though DAO avoids this internally
+        assertEquals(ScriptEnginePersonAttributeDao.getScriptEngineName("not a filename = a script"), null);
+        // test with classpath resource
+        assertEquals(ScriptEnginePersonAttributeDao.getScriptEngineName("SampleScriptedJavascriptPersonAttributeDao.js"), "nashorn");
+        assertEquals(ScriptEnginePersonAttributeDao.getScriptEngineName("src/test/resources/SampleScriptedJavascriptPersonAttributeDao.js"), "nashorn");
+        assertEquals(ScriptEnginePersonAttributeDao.getScriptEngineName("src/test/resources/SampleScriptedGroovyPersonAttributeDao.groovy"), "groovy");
+        // note jython not in classpath so null is expected return value, also test.py file doesn't exist
+        assertEquals(ScriptEnginePersonAttributeDao.getScriptEngineName("test.py"), null);
+    }
+
+    @Test
+    public void testDetermineScriptType() {
+        // test with classpath resource
+        assertEquals(new ScriptEnginePersonAttributeDao("SampleScriptedJavascriptPersonAttributeDao.js").getScriptType(),
+                ScriptEnginePersonAttributeDao.SCRIPT_TYPE.RESOURCE);
+        assertEquals(new ScriptEnginePersonAttributeDao("src/test/resources/SampleScriptedJavascriptPersonAttributeDao.js").getScriptType(),
+                ScriptEnginePersonAttributeDao.SCRIPT_TYPE.FILE);
+        // if file doesn't exist, assume script is contents of string
+        assertEquals(new ScriptEnginePersonAttributeDao("doesnotexist/src/test/resources/SampleScriptedJavascriptPersonAttributeDao.js").getScriptType(),
+                ScriptEnginePersonAttributeDao.SCRIPT_TYPE.CONTENTS);
     }
 }


### PR DESCRIPTION
This should be compatible with previous version but it won't set engine
to python based on path of test.py if python engine not on classpath.

This fixes a few logging bugs and bug in one of the constructors that is
from my previous commit (calling getEngineName() to set enginename)

This also avoids checking for file and classpath contents every time the
script is run, now type of script is determined when scriptFile is set
in constructor or via setter.

Changes to scripts will be still be picked up b/c script files or classpath
resources are still re-read each time script runs, as before.