### PR TITLE
Avoid nesting unmodifiable collections and maps.

### DIFF
--- a/person-directory-impl/src/main/java/org/apereo/services/persondir/support/AbstractAggregatingDefaultQueryPersonAttributeDao.java
+++ b/person-directory-impl/src/main/java/org/apereo/services/persondir/support/AbstractAggregatingDefaultQueryPersonAttributeDao.java
@@ -25,11 +25,11 @@ import org.apereo.services.persondir.IPersonAttributeDaoFilter;
 import org.apereo.services.persondir.IPersonAttributes;
 import org.apereo.services.persondir.support.merger.IAttributeMerger;
 import org.apereo.services.persondir.support.merger.MultivaluedAttributeMerger;
+import org.apereo.services.persondir.util.CollectionsUtil;
 import org.springframework.beans.factory.annotation.Required;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -190,7 +190,7 @@ public abstract class AbstractAggregatingDefaultQueryPersonAttributeDao extends 
             this.logger.debug("Aggregated search results '" + resultPeople + "' for query='" + query + "'");
         }
 
-        return Collections.unmodifiableSet(resultPeople);
+        return CollectionsUtil.safelyWrapAsUnmodifiableSet(resultPeople);
     }
 
     private boolean handleRuntimeException(IPersonAttributeDao currentlyConsidering, RuntimeException rte) {
@@ -274,7 +274,7 @@ public abstract class AbstractAggregatingDefaultQueryPersonAttributeDao extends 
             return null;
         }
 
-        return Collections.unmodifiableSet(attrNames);
+        return CollectionsUtil.safelyWrapAsUnmodifiableSet(attrNames);
     }
 
     /**
@@ -331,7 +331,7 @@ public abstract class AbstractAggregatingDefaultQueryPersonAttributeDao extends 
             return null;
         }
 
-        return Collections.unmodifiableSet(queryAttrs);
+        return CollectionsUtil.safelyWrapAsUnmodifiableSet(queryAttrs);
     }
 
     /**
@@ -373,7 +373,7 @@ public abstract class AbstractAggregatingDefaultQueryPersonAttributeDao extends 
     @Required
     public final void setPersonAttributeDaos(final List<IPersonAttributeDao> daos) {
         Validate.notNull(daos, "The IPersonAttributeDao List cannot be null");
-        this.personAttributeDaos = Collections.unmodifiableList(daos);
+        this.personAttributeDaos = CollectionsUtil.safelyWrapAsUnmodifiableList(daos);
     }
 
     /**

--- a/person-directory-impl/src/main/java/org/apereo/services/persondir/support/AbstractQueryPersonAttributeDao.java
+++ b/person-directory-impl/src/main/java/org/apereo/services/persondir/support/AbstractQueryPersonAttributeDao.java
@@ -25,10 +25,10 @@ import org.apereo.services.persondir.IPersonAttributeDaoFilter;
 import org.apereo.services.persondir.support.jdbc.AbstractJdbcPersonAttributeDao;
 import org.apereo.services.persondir.IPersonAttributes;
 import org.apereo.services.persondir.util.CaseCanonicalizationMode;
+import org.apereo.services.persondir.util.CollectionsUtil;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -259,7 +259,7 @@ public abstract class AbstractQueryPersonAttributeDao<QB> extends AbstractDefaul
             mappedPeople.add(mappedPerson);
         }
 
-        return Collections.unmodifiableSet(mappedPeople);
+        return CollectionsUtil.safelyWrapAsUnmodifiableSet(mappedPeople);
     }
 
     /* (non-Javadoc)

--- a/person-directory-impl/src/main/java/org/apereo/services/persondir/support/AdditionalDescriptors.java
+++ b/person-directory-impl/src/main/java/org/apereo/services/persondir/support/AdditionalDescriptors.java
@@ -24,9 +24,9 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 import org.apereo.services.persondir.IPersonAttributes;
+import org.apereo.services.persondir.util.CollectionsUtil;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -66,13 +66,12 @@ public class AdditionalDescriptors implements IAdditionalDescriptors {
         if (values == null) {
             return null;
         }
-
-        return Collections.unmodifiableList(values);
+        return CollectionsUtil.safelyWrapAsUnmodifiableList(values);
     }
 
     @Override
     public Map<String, List<Object>> getAttributes() {
-        return Collections.unmodifiableMap(this.attributes);
+        return CollectionsUtil.safelyWrapAsUnmodifiableMap(this.attributes);
     }
 
     @Override

--- a/person-directory-impl/src/main/java/org/apereo/services/persondir/support/BasePersonImpl.java
+++ b/person-directory-impl/src/main/java/org/apereo/services/persondir/support/BasePersonImpl.java
@@ -24,12 +24,12 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 import org.apereo.services.persondir.IPersonAttributes;
+import org.apereo.services.persondir.util.CollectionsUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.Array;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -54,7 +54,7 @@ public abstract class BasePersonImpl implements IPersonAttributes {
         // in AbstractQueryPersonAttributeDao.mapPersonAttributes when the CaseInsensitive*Impl.java
         // subclasses are used.  James W 6/15
         // See https://issues.jasig.org/browse/PERSONDIR-89
-        this.attributes = Collections.unmodifiableMap(immutableValuesBuilder);
+        this.attributes = CollectionsUtil.safelyWrapAsUnmodifiableMap(immutableValuesBuilder);
     }
 
     /**
@@ -91,7 +91,7 @@ public abstract class BasePersonImpl implements IPersonAttributes {
                         }
                     }
                 }
-                value = Collections.unmodifiableList(value);
+                value = CollectionsUtil.safelyWrapAsUnmodifiableList(value);
             }
             if (logger.isTraceEnabled()) {
                 logger.trace("Collecting attribute {} with value(s) {}", key, value);

--- a/person-directory-impl/src/main/java/org/apereo/services/persondir/support/ComplexStubPersonAttributeDao.java
+++ b/person-directory-impl/src/main/java/org/apereo/services/persondir/support/ComplexStubPersonAttributeDao.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apereo.services.persondir.IPersonAttributeDao;
 import org.apereo.services.persondir.IPersonAttributeDaoFilter;
 import org.apereo.services.persondir.IPersonAttributes;
+import org.apereo.services.persondir.util.CollectionsUtil;
 import org.apereo.services.persondir.util.PatternHelper;
 
 import java.util.ArrayList;
@@ -255,7 +256,7 @@ public class ComplexStubPersonAttributeDao extends AbstractQueryPersonAttributeD
             possibleAttribNames.addAll(keySet);
         }
 
-        this.possibleUserAttributeNames = Collections.unmodifiableSet(possibleAttribNames);
+        this.possibleUserAttributeNames = CollectionsUtil.safelyWrapAsUnmodifiableSet(possibleAttribNames);
     }
 }
 

--- a/person-directory-impl/src/main/java/org/apereo/services/persondir/support/RegexGatewayPersonAttributeDao.java
+++ b/person-directory-impl/src/main/java/org/apereo/services/persondir/support/RegexGatewayPersonAttributeDao.java
@@ -23,6 +23,7 @@ import org.apache.commons.lang3.Validate;
 import org.apereo.services.persondir.IPersonAttributeDao;
 import org.apereo.services.persondir.IPersonAttributeDaoFilter;
 import org.apereo.services.persondir.IPersonAttributes;
+import org.apereo.services.persondir.util.CollectionsUtil;
 
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -161,8 +162,7 @@ public final class RegexGatewayPersonAttributeDao extends AbstractDefaultAttribu
 
             newPatterns.put(attribute, compiledPattern);
         }
-
-        this.patterns = Collections.unmodifiableMap(newPatterns);
+        this.patterns = CollectionsUtil.safelyWrapAsUnmodifiableMap(newPatterns);
     }
 
     /**

--- a/person-directory-impl/src/main/java/org/apereo/services/persondir/support/jdbc/NamedParameterJdbcPersonAttributeDao.java
+++ b/person-directory-impl/src/main/java/org/apereo/services/persondir/support/jdbc/NamedParameterJdbcPersonAttributeDao.java
@@ -23,6 +23,7 @@ import org.apereo.services.persondir.IPersonAttributes;
 import org.apereo.services.persondir.support.AbstractDefaultAttributePersonAttributeDao;
 import org.apereo.services.persondir.support.CaseInsensitiveNamedPersonImpl;
 import org.apereo.services.persondir.support.IUsernameAttributeProvider;
+import org.apereo.services.persondir.util.CollectionsUtil;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Required;
 import org.springframework.jdbc.core.RowCallbackHandler;
@@ -101,12 +102,12 @@ public class NamedParameterJdbcPersonAttributeDao extends AbstractDefaultAttribu
     }
 
     public void setAvailableQueryAttributes(final Set<String> availableQueryAttributes) {
-        this.availableQueryAttributes = Collections.unmodifiableSet(availableQueryAttributes);
+        this.availableQueryAttributes = CollectionsUtil.safelyWrapAsUnmodifiableSet(availableQueryAttributes);
     }
 
     @Required
     public void setUserAttributeNames(final Set<String> userAttributeNames) {
-        this.userAttributeNames = Collections.unmodifiableSet(userAttributeNames);
+        this.userAttributeNames = CollectionsUtil.safelyWrapAsUnmodifiableSet(userAttributeNames);
     }
 
     @Override

--- a/person-directory-impl/src/main/java/org/apereo/services/persondir/support/rule/DeclaredRulePersonAttributeDao.java
+++ b/person-directory-impl/src/main/java/org/apereo/services/persondir/support/rule/DeclaredRulePersonAttributeDao.java
@@ -26,9 +26,9 @@ import org.apereo.services.persondir.IPersonAttributes;
 import org.apereo.services.persondir.support.AbstractDefaultAttributePersonAttributeDao;
 import org.apereo.services.persondir.support.IUsernameAttributeProvider;
 import org.apereo.services.persondir.support.SimpleUsernameAttributeProvider;
+import org.apereo.services.persondir.util.CollectionsUtil;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -109,7 +109,7 @@ public final class DeclaredRulePersonAttributeDao extends AbstractDefaultAttribu
     public void setRules(final List<AttributeRule> rules) {
         Validate.notEmpty(rules, "Argument 'rules' cannot be null or empty.");
 
-        this.rules = Collections.unmodifiableList(new ArrayList<>(rules));
+        this.rules = CollectionsUtil.safelyWrapAsUnmodifiableList(new ArrayList<>(rules));
     }
 
     /* (non-Javadoc)

--- a/person-directory-impl/src/main/java/org/apereo/services/persondir/support/xml/XmlPersonAttributeDao.java
+++ b/person-directory-impl/src/main/java/org/apereo/services/persondir/support/xml/XmlPersonAttributeDao.java
@@ -28,13 +28,13 @@ import org.apereo.services.persondir.support.NamedPersonImpl;
 import org.apereo.services.persondir.support.xml.CachingJaxbLoader.UnmarshallingCallback;
 import org.apereo.services.persondir.support.xml.om.Attribute;
 import org.apereo.services.persondir.support.xml.om.Person;
+import org.apereo.services.persondir.util.CollectionsUtil;
 import org.apereo.services.persondir.util.PatternHelper;
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.core.io.Resource;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -286,9 +286,9 @@ public class XmlPersonAttributeDao extends AbstractDefaultAttributePersonAttribu
                 }
             }
 
-            XmlPersonAttributeDao.this.attributesCache = Collections.unmodifiableSet(attributeNames);
-            XmlPersonAttributeDao.this.personByAttributeCache = Collections.unmodifiableMap(personByAttributeCache);
-            XmlPersonAttributeDao.this.personByNameCache = Collections.unmodifiableMap(personByNameCache);
+            XmlPersonAttributeDao.this.attributesCache = CollectionsUtil.safelyWrapAsUnmodifiableSet(attributeNames);
+            XmlPersonAttributeDao.this.personByAttributeCache = CollectionsUtil.safelyWrapAsUnmodifiableMap(personByAttributeCache);
+            XmlPersonAttributeDao.this.personByNameCache = CollectionsUtil.safelyWrapAsUnmodifiableMap(personByNameCache);
         }
     }
 }

--- a/person-directory-impl/src/main/java/org/apereo/services/persondir/util/CollectionsUtil.java
+++ b/person-directory-impl/src/main/java/org/apereo/services/persondir/util/CollectionsUtil.java
@@ -1,0 +1,41 @@
+package org.apereo.services.persondir.util;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Utility class to avoid nested Unmodifiable collections.
+ *
+ * Can't use instanceof b/c classes are not public and there are multiple sub-types of
+ * Unmodifiable classes so doing an equality check against the class name doesn't work
+ * hence the use of contains.
+ */
+public class CollectionsUtil {
+
+    public static boolean isUnmodifiableMap(Map map) {
+        return (map != null && map.getClass().getSimpleName().contains("Unmodifiable"));
+    }
+
+    public static boolean isUnmodifiableCollection(Collection coll) {
+        return (coll != null && coll.getClass().getSimpleName().contains("Unmodifiable"));
+    }
+
+    public static <K,V> Map<K, V> safelyWrapAsUnmodifiableMap(Map<K, V> map) {
+        return isUnmodifiableMap(map) ? map : Collections.unmodifiableMap(map);
+    }
+
+    public static <T> Collection<T> safelyWrapAsUnmodifiableCollection(Collection<T> collection) {
+        return isUnmodifiableCollection(collection)? collection : Collections.unmodifiableCollection(collection);
+    }
+
+    public static <T> Set<T> safelyWrapAsUnmodifiableSet(Set<T> set) {
+        return isUnmodifiableCollection(set) ? set : Collections.unmodifiableSet(set);
+    }
+
+    public static <T> List<T> safelyWrapAsUnmodifiableList(List<T> list) {
+        return isUnmodifiableCollection(list) ? list : Collections.unmodifiableList(list);
+    }
+}

--- a/person-directory-impl/src/main/java/org/apereo/services/persondir/util/CollectionsUtil.java
+++ b/person-directory-impl/src/main/java/org/apereo/services/persondir/util/CollectionsUtil.java
@@ -7,11 +7,18 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * Utility class to avoid nested Unmodifiable collections.
+ * Utility class to avoid deeply nested Unmodifiable collections and accompanying stack overflow.
  *
- * Can't use instanceof b/c classes are not public and there are multiple sub-types of
- * Unmodifiable classes so doing an equality check against the class name doesn't work
- * hence the use of contains.
+ * If a collection or map is wrapped with an Unmodifiable wrapper repeatedly, eventually
+ * a call to `get()` an item will result in a StackOverflowError.
+ * It can be difficult to keep track of whether a collection has already been wrapped
+ * since the classes are not public so an instanceof check won't work.
+ *
+ * There are multiple sub-types of Unmodifiable classes so doing an equality check
+ * against the class name doesn't work hence the use of contains looking for the word
+ * "Unmodifiable" in the class name.
+ *
+ * This class should eventually go away if the JDK provides a solution.
  */
 public class CollectionsUtil {
 

--- a/person-directory-impl/src/test/java/org/apereo/services/persondir/support/GroovyPersonAttributeDaoTest.java
+++ b/person-directory-impl/src/test/java/org/apereo/services/persondir/support/GroovyPersonAttributeDaoTest.java
@@ -86,9 +86,7 @@ public class GroovyPersonAttributeDaoTest extends AbstractPersonAttributeDaoTest
     public void testGetPerson() {
         final IPersonAttributes attrs = dao.getPerson("userid", IPersonAttributeDaoFilter.alwaysChoose());
         assertFalse(attrs.getAttributes().isEmpty());
-
         assertEquals(getAttributeAsSingleValue(attrs, "name"), "userid");
-
         assertEquals(getAttributeAsList(attrs, "likes").size(), 2);
     }
 

--- a/person-directory-impl/src/test/java/org/apereo/services/persondir/support/MultivaluedPersonAttributeUtilsTest.java
+++ b/person-directory-impl/src/test/java/org/apereo/services/persondir/support/MultivaluedPersonAttributeUtilsTest.java
@@ -19,6 +19,7 @@
 package org.apereo.services.persondir.support;
 
 import junit.framework.TestCase;
+import org.apereo.services.persondir.util.CollectionsUtil;
 import org.apereo.services.persondir.util.Util;
 
 import java.util.ArrayList;
@@ -199,7 +200,7 @@ public class MultivaluedPersonAttributeUtilsTest extends TestCase {
      * Test that attempting to add a result with a null value yields no change.
      */
     public void testAddResultNullValue() {
-        final Map<String, List<String>> immutableMap = Collections.unmodifiableMap(new HashMap<String, List<String>>());
+        final Map<String, List<String>> immutableMap = CollectionsUtil.safelyWrapAsUnmodifiableMap(new HashMap<String, List<String>>());
         MultivaluedPersonAttributeUtils.addResult(immutableMap, "key", null);
     }
 


### PR DESCRIPTION
This avoids deep nesting of unmodifiable collections and maps which eventually results in a stackoverflow exception. I don't know if all of them are required but a CAS test that was failing ran much faster and didn't die when I used this code. I don't think the overhead of this safety check is significant. If the type of code I put in the CollectionUtil class is available in some existing Collection utility then I would prefer to use that.

https://github.com/apereo/cas/pull/4086
