### PR TITLE
update groovy to 2.5.9

### DIFF
--- a/person-directory-impl/pom.xml
+++ b/person-directory-impl/pom.xml
@@ -210,7 +210,13 @@
         </dependency>
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-all</artifactId>
+            <artifactId>groovy</artifactId>
+            <scope>compile</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-jsr223</artifactId>
             <scope>compile</scope>
             <optional>true</optional>
         </dependency>

--- a/person-directory-impl/src/test/java/org/apereo/services/persondir/support/ScriptEnginePersonAttributeDaoTest.java
+++ b/person-directory-impl/src/test/java/org/apereo/services/persondir/support/ScriptEnginePersonAttributeDaoTest.java
@@ -43,8 +43,8 @@ public class ScriptEnginePersonAttributeDaoTest extends AbstractPersonAttributeD
         this.dao.setScriptFile("SampleScriptedJavascriptPersonAttributeDao.js");
         final IPersonAttributes person = this.dao.getPerson("testuser", IPersonAttributeDaoFilter.alwaysChoose());
         assertNotNull(person);
-        assertEquals(person.getName(), "testuser");
-        assertEquals(person.getAttributes().size(), 4);
+        assertEquals("testuser", person.getName());
+        assertEquals(4, person.getAttributes().size());
     }
 
     @Test
@@ -52,8 +52,8 @@ public class ScriptEnginePersonAttributeDaoTest extends AbstractPersonAttributeD
         this.dao.setScriptFile("SampleScriptedGroovyPersonAttributeDao.groovy");
         final IPersonAttributes person = this.dao.getPerson("testuser", IPersonAttributeDaoFilter.alwaysChoose());
         assertNotNull(person);
-        assertEquals(person.getName(), "testuser");
-        assertEquals(person.getAttributes().size(), 4);
+        assertEquals("testuser", person.getName());
+        assertEquals(4, person.getAttributes().size());
     }
 
     @Test
@@ -62,8 +62,8 @@ public class ScriptEnginePersonAttributeDaoTest extends AbstractPersonAttributeD
         this.dao.setEngineName("groovy");
         final IPersonAttributes person = this.dao.getPerson("testuser", IPersonAttributeDaoFilter.alwaysChoose());
         assertNotNull(person);
-        assertEquals(person.getName(), "testuser");
-        assertEquals(person.getAttributes().size(), 4);
+        assertEquals("testuser", person.getName());
+        assertEquals(4, person.getAttributes().size() );
     }
 
     @Test
@@ -73,31 +73,28 @@ public class ScriptEnginePersonAttributeDaoTest extends AbstractPersonAttributeD
         query.put("username", Util.list("testuser"));
         final Set<IPersonAttributes> personSet = this.dao.getPeopleWithMultivaluedAttributes(query, IPersonAttributeDaoFilter.alwaysChoose());
         assertNotNull(personSet);
-        assertEquals(personSet.size(), 1);
-        assertEquals(((IPersonAttributes) personSet.iterator().next()).getName(), "testuser");
+        assertEquals(1, personSet.size());
+        assertEquals("testuser", ((IPersonAttributes) personSet.iterator().next()).getName());
     }
 
     @Test
     public void testGetScriptEngineName() {
         // test with an inline script, even though DAO avoids this internally
-        assertEquals(ScriptEnginePersonAttributeDao.getScriptEngineName("not a filename = a script"), null);
+        assertNull(ScriptEnginePersonAttributeDao.getScriptEngineName("not a filename = a script"));
         // test with classpath resource
-        assertEquals(ScriptEnginePersonAttributeDao.getScriptEngineName("SampleScriptedJavascriptPersonAttributeDao.js"), "nashorn");
-        assertEquals(ScriptEnginePersonAttributeDao.getScriptEngineName("src/test/resources/SampleScriptedJavascriptPersonAttributeDao.js"), "nashorn");
-        assertEquals(ScriptEnginePersonAttributeDao.getScriptEngineName("src/test/resources/SampleScriptedGroovyPersonAttributeDao.groovy"), "groovy");
+        assertEquals("nashorn", ScriptEnginePersonAttributeDao.getScriptEngineName("SampleScriptedJavascriptPersonAttributeDao.js"));
+        assertEquals("nashorn", ScriptEnginePersonAttributeDao.getScriptEngineName("src/test/resources/SampleScriptedJavascriptPersonAttributeDao.js"));
+        assertEquals("groovy", ScriptEnginePersonAttributeDao.getScriptEngineName("src/test/resources/SampleScriptedGroovyPersonAttributeDao.groovy"));
         // note jython not in classpath so null is expected return value, also test.py file doesn't exist
-        assertEquals(ScriptEnginePersonAttributeDao.getScriptEngineName("test.py"), null);
+        assertNull(ScriptEnginePersonAttributeDao.getScriptEngineName("test.py") );
     }
 
     @Test
     public void testDetermineScriptType() {
         // test with classpath resource
-        assertEquals(new ScriptEnginePersonAttributeDao("SampleScriptedJavascriptPersonAttributeDao.js").getScriptType(),
-                ScriptEnginePersonAttributeDao.SCRIPT_TYPE.RESOURCE);
-        assertEquals(new ScriptEnginePersonAttributeDao("src/test/resources/SampleScriptedJavascriptPersonAttributeDao.js").getScriptType(),
-                ScriptEnginePersonAttributeDao.SCRIPT_TYPE.FILE);
+        assertEquals(ScriptEnginePersonAttributeDao.SCRIPT_TYPE.RESOURCE, new ScriptEnginePersonAttributeDao("SampleScriptedJavascriptPersonAttributeDao.js").getScriptType());
+        assertEquals(ScriptEnginePersonAttributeDao.SCRIPT_TYPE.FILE, new ScriptEnginePersonAttributeDao("src/test/resources/SampleScriptedJavascriptPersonAttributeDao.js").getScriptType());
         // if file doesn't exist, assume script is contents of string
-        assertEquals(new ScriptEnginePersonAttributeDao("doesnotexist/src/test/resources/SampleScriptedJavascriptPersonAttributeDao.js").getScriptType(),
-                ScriptEnginePersonAttributeDao.SCRIPT_TYPE.CONTENTS);
+        assertEquals(ScriptEnginePersonAttributeDao.SCRIPT_TYPE.CONTENTS, new ScriptEnginePersonAttributeDao("doesnotexist/src/test/resources/SampleScriptedJavascriptPersonAttributeDao.js").getScriptType());
     }
 }

--- a/person-directory-impl/src/test/resources/SampleScriptedGroovyPersonAttributeDao.groovy
+++ b/person-directory-impl/src/test/resources/SampleScriptedGroovyPersonAttributeDao.groovy
@@ -4,7 +4,7 @@ Map<String, List<Object>> run(final Object... args) {
     def uid = args[0]
     def logger = args[1]
 
-    logger.debug("Things are happening just fine")
+    logger.debug("Things are happening just fine with uid: " + uid)
     return[username:[uid], likes:["cheese", "food"], id:[1234,2,3,4,5], another:"attribute"]
 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <spring-ldap.version>2.3.2.RELEASE</spring-ldap.version>
         <spring-security.version>5.2.1.RELEASE</spring-security.version>
         <spring-modules.version>0.8a</spring-modules.version>
-        <groovy.version>2.4.18</groovy.version>
+        <groovy.version>2.5.9</groovy.version>
         <grouper.client.version>2.4.0</grouper.client.version>
         <guava.version>28.2-jre</guava.version>
         <toml.version>1.0.0</toml.version>
@@ -461,7 +461,13 @@
             </dependency>
             <dependency>
                 <groupId>org.codehaus.groovy</groupId>
-                <artifactId>groovy-all</artifactId>
+                <artifactId>groovy</artifactId>
+                <version>${groovy.version}</version>
+                <scope>compile</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.groovy</groupId>
+                <artifactId>groovy-jsr223</artifactId>
                 <version>${groovy.version}</version>
                 <scope>compile</scope>
             </dependency>


### PR DESCRIPTION
Switched from groovy-all which is now pom dependency that brings in too many jars including some that are incompatible with the junit version used currently. Also fix order of some test assertions.