### PR TITLE
remove all deprecated methods for 2.0 release

### DIFF
--- a/person-directory-api/src/main/java/org/apereo/services/persondir/IPersonAttributeDao.java
+++ b/person-directory-api/src/main/java/org/apereo/services/persondir/IPersonAttributeDao.java
@@ -115,58 +115,6 @@ public interface IPersonAttributeDao extends Comparable<IPersonAttributeDao> {
      */
     Set<String> getAvailableQueryAttributes(IPersonAttributeDaoFilter filter);
 
-
-    /**
-     * Returns a mutable {@link Map} of the attributes of the first {@link IPersonAttributes} returned by calling
-     * {@link #getPeople(Map, IPersonAttributeDaoFilter)}
-     *
-     * @param seed   A {@link Map} of name/value pair attributes to use in searching for {@link IPersonAttributes}s
-     * @param filter the filter
-     * @return A {@link Map} of PersonAttributess that match the query {@link Map}. If no matches are found an empty {@link Map} is returned. If the query could not be run null is returned.
-     * @deprecated Use {@link #getPeople(Map, IPersonAttributeDaoFilter)} instead. This method will be removed in 1.6
-     */
-    @Deprecated
-    Map<String, List<Object>> getMultivaluedUserAttributes(Map<String, List<Object>> seed,
-                                                           IPersonAttributeDaoFilter filter);
-
-    /**
-     * Returns a mutable {@link Map} of the attributes of the {@link IPersonAttributes} returned by calling
-     * {@link #getPerson(String, IPersonAttributeDaoFilter)}
-     *
-     * @param uid    The userName of the person to find.
-     * @param filter the filter
-     * @return The populated {@link Map} of person attributes for the specified uid, null if no person could be found for the uid.
-     * @deprecated Use {@link #getPerson(String, IPersonAttributeDaoFilter)} instead. This method will be removed in 1.6
-     */
-    @Deprecated
-    Map<String, List<Object>> getMultivaluedUserAttributes(String uid, IPersonAttributeDaoFilter filter);
-
-    /**
-     * Returns a mutable {@link Map} of the single-valued attributes of the first {@link IPersonAttributes} returned by calling
-     * {@link #getPeople(Map, IPersonAttributeDaoFilter)}
-     *
-     * @param seed   A {@link Map} of name/value pair attributes to use in searching for {@link IPersonAttributes}s
-     * @param filter the filter
-     * @return A {@link Map} of PersonAttributess that match the query {@link Map}. If no matches are found an empty {@link Map} is returned. If the query could not be run null is returned.
-     * @deprecated Use {@link #getPeople(Map, IPersonAttributeDaoFilter)} instead. This method will be removed in 1.6
-     */
-    @Deprecated
-    Map<String, Object> getUserAttributes(Map<String, Object> seed,
-                                          IPersonAttributeDaoFilter filter);
-
-    /**
-     * Returns a mutable {@link Map} of the single-valued attributes of the {@link IPersonAttributes} returned by calling
-     * {@link #getPerson(String, IPersonAttributeDaoFilter)}
-     *
-     * @param uid    The userName of the person to find.
-     * @param filter the filter
-     * @return The populated {@link Map} of person attributes for the specified uid, null if no person could be found for the uid.
-     * @deprecated Use {@link #getPerson(String, IPersonAttributeDaoFilter)} instead. This method will be removed in 1.6
-     */
-    @Deprecated
-    Map<String, Object> getUserAttributes(String uid,
-                                          IPersonAttributeDaoFilter filter);
-
     /**
      * Describes the order by which this DAO may be sorted
      * and put into an ordered collection.

--- a/person-directory-impl/src/main/java/org/apereo/services/persondir/support/AbstractFlatteningPersonAttributeDao.java
+++ b/person-directory-impl/src/main/java/org/apereo/services/persondir/support/AbstractFlatteningPersonAttributeDao.java
@@ -49,15 +49,4 @@ public abstract class AbstractFlatteningPersonAttributeDao extends BasePersonAtt
         final Map<String, List<Object>> multivaluedSeed = MultivaluedPersonAttributeUtils.toMultivaluedMap(query);
         return this.getPeopleWithMultivaluedAttributes(multivaluedSeed, filter);
     }
-
-    /**
-     * @deprecated Use {@link MultivaluedPersonAttributeUtils#toMultivaluedMap(Map)} instead. This will be removed in 1.6
-     *
-     * @param seed Map of seed names and values
-     * @return Map of seed names with list of values
-     */
-    @Deprecated
-    protected Map<String, List<Object>> toMultivaluedSeed(final Map<String, Object> seed) {
-        return MultivaluedPersonAttributeUtils.toMultivaluedMap(seed);
-    }
 }

--- a/person-directory-impl/src/main/java/org/apereo/services/persondir/support/AbstractQueryPersonAttributeDao.java
+++ b/person-directory-impl/src/main/java/org/apereo/services/persondir/support/AbstractQueryPersonAttributeDao.java
@@ -272,8 +272,7 @@ public abstract class AbstractQueryPersonAttributeDao<QB> extends AbstractDefaul
             return new HashSet<>();
         }
 
-        final Set list = new HashSet(this.queryAttributeMapping.keySet());
-        return list;
+        return new HashSet<>(this.queryAttributeMapping.keySet());
     }
 
     /* (non-Javadoc)

--- a/person-directory-impl/src/main/java/org/apereo/services/persondir/support/BasePersonImpl.java
+++ b/person-directory-impl/src/main/java/org/apereo/services/persondir/support/BasePersonImpl.java
@@ -73,7 +73,7 @@ public abstract class BasePersonImpl implements IPersonAttributes {
             if (value != null) {
                 if (!value.isEmpty()) {
                     final Object result = value.get(0);
-                    if (Array.class.isInstance(result)) {
+                    if (result instanceof Array) {
                         if (logger.isTraceEnabled()) {
                             logger.trace("Column {} is classified as a SQL array", key);
                         }
@@ -130,12 +130,7 @@ public abstract class BasePersonImpl implements IPersonAttributes {
      */
     @Override
     public List<Object> getAttributeValues(final String name) {
-        final List<Object> values = this.attributes.get(name);
-        if (values == null) {
-            return null;
-        }
-
-        return values;
+        return this.attributes.get(name);
     }
 
     /* (non-Javadoc)

--- a/person-directory-impl/src/main/java/org/apereo/services/persondir/support/CachingPersonAttributeDaoImpl.java
+++ b/person-directory-impl/src/main/java/org/apereo/services/persondir/support/CachingPersonAttributeDaoImpl.java
@@ -74,16 +74,6 @@ import java.util.Set;
  * <td valign="top">null</td>
  * </tr>
  * <tr>
- * <td  valign="top">cacheKeyAttributes</td>
- * <td>
- * A Set of attribute names to use when building the cache key. The default
- * implementation generates the key as a Map of attributeNames to values retrieved
- * from the seed for the query. Zero length sets are treaded as null.
- * </td>
- * <td valign="top">No</td>
- * <td valign="top">null</td>
- * </tr>
- * <tr>
  * <td  valign="top">cacheNullResults</td>
  * <td>
  * If the wrapped IPersonAttributeDao returns null for the query should that null
@@ -119,7 +109,7 @@ public class CachingPersonAttributeDaoImpl extends AbstractDefaultAttributePerso
     private long misses = 0;
 
     static {
-        NULL_RESULTS_OBJECT = new HashSet();
+        NULL_RESULTS_OBJECT = new HashSet<>();
         NULL_RESULTS_OBJECT.add(new SingletonPersonImpl());
     }
 
@@ -137,11 +127,6 @@ public class CachingPersonAttributeDaoImpl extends AbstractDefaultAttributePerso
      * The cache to store query results in.
      */
     private Map<Serializable, Set<IPersonAttributes>> userInfoCache = null;
-
-    /*
-     * The set of attributes to use to generate the cache key.
-     */
-    private Set<String> cacheKeyAttributes = null;
 
     /*
      * If null resutls should be cached
@@ -173,24 +158,6 @@ public class CachingPersonAttributeDaoImpl extends AbstractDefaultAttributePerso
         }
 
         this.cachedPersonAttributesDao = cachedPersonAttributesDao;
-    }
-
-    /**
-     * @return Returns the cacheKeyAttributes.
-     * @deprecated these should be retrieved from the provided {@link CacheKeyGenerator} if applicable
-     */
-    @Deprecated
-    public Set<String> getCacheKeyAttributes() {
-        return this.cacheKeyAttributes;
-    }
-
-    /**
-     * @param cacheKeyAttributes The cacheKeyAttributes to set.
-     * @deprecated these should be set on the provided {@link CacheKeyGenerator} if applicable
-     */
-    @Deprecated
-    public void setCacheKeyAttributes(final Set<String> cacheKeyAttributes) {
-        this.cacheKeyAttributes = cacheKeyAttributes;
     }
 
     /**
@@ -279,10 +246,9 @@ public class CachingPersonAttributeDaoImpl extends AbstractDefaultAttributePerso
      * @see org.springframework.beans.factory.InitializingBean#afterPropertiesSet()
      */
     @Override
-    public void afterPropertiesSet() throws Exception {
+    public void afterPropertiesSet() {
         if (this.cacheKeyGenerator == null) {
             final AttributeBasedCacheKeyGenerator cacheKeyGenerator = new AttributeBasedCacheKeyGenerator();
-            cacheKeyGenerator.setCacheKeyAttributes(this.cacheKeyAttributes);
 
             final IUsernameAttributeProvider usernameAttributeProvider = this.getUsernameAttributeProvider();
             final String usernameAttribute = usernameAttributeProvider.getUsernameAttribute();
@@ -463,7 +429,7 @@ public class CachingPersonAttributeDaoImpl extends AbstractDefaultAttributePerso
         }
 
         @Override
-        public Object proceed() throws Throwable {
+        public Object proceed() {
             throw new UnsupportedOperationException("This is a fake MethodInvocation, proceed() is not supported.");
         }
     }
@@ -473,7 +439,7 @@ public class CachingPersonAttributeDaoImpl extends AbstractDefaultAttributePerso
 
         @SuppressWarnings("unchecked")
         public SingletonPersonImpl() {
-            super(new HashMap<String, List<Object>>());
+            super(new HashMap<>());
         }
 
         @Override

--- a/person-directory-impl/src/main/java/org/apereo/services/persondir/support/CaseInsensitiveAttributeNamedPersonImpl.java
+++ b/person-directory-impl/src/main/java/org/apereo/services/persondir/support/CaseInsensitiveAttributeNamedPersonImpl.java
@@ -45,6 +45,6 @@ public class CaseInsensitiveAttributeNamedPersonImpl extends AttributeNamedPerso
 
     @Override
     protected Map<String, List<Object>> createImmutableAttributeMap(int size) {
-        return new TreeMap(String.CASE_INSENSITIVE_ORDER);
+        return new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
     }
 }

--- a/person-directory-impl/src/main/java/org/apereo/services/persondir/support/ComplexStubPersonAttributeDao.java
+++ b/person-directory-impl/src/main/java/org/apereo/services/persondir/support/ComplexStubPersonAttributeDao.java
@@ -40,7 +40,7 @@ import java.util.regex.Pattern;
 
 
 /**
- * Looks up the user's attribute Map in the backingMap. If using the {@link IPersonAttributeDao#getUserAttributes(Map, org.apereo.services.persondir.IPersonAttributeDaoFilter)}
+ * Looks up the user's attribute Map in the backingMap. If using the {@link IPersonAttributeDao#getPeople(Map, org.apereo.services.persondir.IPersonAttributeDaoFilter)}
  * method the attribute value returned for the key {@link #getUsernameAttributeProvider()} will
  * be used as the key for the backingMap.
  *
@@ -60,7 +60,7 @@ import java.util.regex.Pattern;
  *             Sets the backing map to use to return user attributes from. The backing map
  *             should have keys of type {@link String} which are the uid for the user. The
  *             values should be of type {@link Map} which follow the Map restrictions decribed
- *             by {@link IPersonAttributeDao#getUserAttributes(Map, org.apereo.services.persondir.IPersonAttributeDaoFilter)}.
+ *             by {@link IPersonAttributeDao#getPeople(Map, org.apereo.services.persondir.IPersonAttributeDaoFilter)}.
  *         </td>
  *         <td valign="top">No</td>
  *         <td valign="top">{@link Collections#EMPTY_MAP}</td>
@@ -144,7 +144,7 @@ public class ComplexStubPersonAttributeDao extends AbstractQueryPersonAttributeD
         final IUsernameAttributeProvider usernameAttributeProvider = this.getUsernameAttributeProvider();
         final String usernameAttribute = usernameAttributeProvider.getUsernameAttribute();
 
-        final Set list = new HashSet();
+        final Set<String> list = new HashSet<>();
         list.add(usernameAttribute);
 
         return list;
@@ -210,7 +210,7 @@ public class ComplexStubPersonAttributeDao extends AbstractQueryPersonAttributeD
         }
 
         final IPersonAttributes person = this.createPerson(seedValue, queryUserName, attributes);
-        final List list = new ArrayList();
+        final List<IPersonAttributes> list = new ArrayList<>();
         list.add(person);
 
         return list;

--- a/person-directory-impl/src/main/java/org/apereo/services/persondir/support/GrouperPersonAttributeDao.java
+++ b/person-directory-impl/src/main/java/org/apereo/services/persondir/support/GrouperPersonAttributeDao.java
@@ -39,8 +39,6 @@ import java.util.Set;
  * <br>
  * This implementation uses Grouper's <i>grouperClient</i> library to query Grouper's back-end repository.
  * <br>
- * Note: This class extends the adapter implementing deprecated methods of <code>IPersonAttributeDao</code> which is scheduled to be removed
- * in person-directory 1.6
  *
  * Note: All the Grouper server connection configuration for grouperClient is defined in
  * <i>grouper.client.properties</i> file and must be available

--- a/person-directory-impl/src/main/java/org/apereo/services/persondir/support/IAdditionalDescriptors.java
+++ b/person-directory-impl/src/main/java/org/apereo/services/persondir/support/IAdditionalDescriptors.java
@@ -34,19 +34,19 @@ public interface IAdditionalDescriptors extends IPersonAttributes {
     /**
      * @param name The user name for the attributes
      */
-    public void setName(String name);
+    void setName(String name);
 
     /**
      * @param attributes Attributes to add to the existing attribute Map
      */
-    public void addAttributes(Map<String, List<Object>> attributes);
+    void addAttributes(Map<String, List<Object>> attributes);
 
     /**
      * This should be atomic to the view of other methods on this interface.
      *
      * @param attributes Replace all existing attributes witht he specified Map
      */
-    public void setAttributes(Map<String, List<Object>> attributes);
+    void setAttributes(Map<String, List<Object>> attributes);
 
     /**
      * Sets the specified attribute values
@@ -55,11 +55,11 @@ public interface IAdditionalDescriptors extends IPersonAttributes {
      * @param values Values for the attribute, may be null
      * @return The previous values for the attribute if they existed
      */
-    public List<Object> setAttributeValues(String name, List<Object> values);
+    List<Object> setAttributeValues(String name, List<Object> values);
 
     /**
      * @param name Removes the specified attribute, must not be null
      * @return The removed values for the attribute if they existed
      */
-    public List<Object> removeAttribute(String name);
+    List<Object> removeAttribute(String name);
 }

--- a/person-directory-impl/src/main/java/org/apereo/services/persondir/support/MicrosoftGraphPersonAttributeDao.java
+++ b/person-directory-impl/src/main/java/org/apereo/services/persondir/support/MicrosoftGraphPersonAttributeDao.java
@@ -76,7 +76,7 @@ public class MicrosoftGraphPersonAttributeDao extends BasePersonAttributeDao {
         for (final Map.Entry<String, ?> stringObjectEntry : personAttributesMap.entrySet()) {
             final Object value = stringObjectEntry.getValue();
             if (value instanceof List) {
-                personAttributes.put(stringObjectEntry.getKey(), (List) value);
+                personAttributes.put(stringObjectEntry.getKey(), (List<Object>) value);
             } else {
                 personAttributes.put(stringObjectEntry.getKey(), new ArrayList<>(Arrays.asList(value)));
             }

--- a/person-directory-impl/src/main/java/org/apereo/services/persondir/support/MultivaluedPersonAttributeUtils.java
+++ b/person-directory-impl/src/main/java/org/apereo/services/persondir/support/MultivaluedPersonAttributeUtils.java
@@ -184,10 +184,10 @@ public final class MultivaluedPersonAttributeUtils {
 
     /**
      * Convert the &lt;String, Object&gt; map to a &lt;String, List&lt;Object&gt;&gt; map by simply wrapping
-     * each value in a singleton (read-only) List
+     * each value in a List, unless Object is already a List in which cas it is returned.
      *
      * @param seed Map of objects
-     * @return Map where each value is a List with the value in it
+     * @return Map where each value is a List with the value(s) in it
      */
     public static Map<String, List<Object>> toMultivaluedMap(final Map<String, Object> seed) {
         Validate.notNull(seed, "seed can not be null");
@@ -196,7 +196,11 @@ public final class MultivaluedPersonAttributeUtils {
         for (final Map.Entry<String, Object> seedEntry : seed.entrySet()) {
             final String seedName = seedEntry.getKey();
             final Object seedValue = seedEntry.getValue();
-            multiSeed.put(seedName, Collections.singletonList(seedValue));
+            if (seedValue instanceof List) {
+                multiSeed.put(seedName, (List<Object>) seedValue);
+            } else {
+                multiSeed.put(seedName, Collections.singletonList(seedValue));
+            }
         }
         return multiSeed;
     }

--- a/person-directory-impl/src/main/java/org/apereo/services/persondir/support/QueryType.java
+++ b/person-directory-impl/src/main/java/org/apereo/services/persondir/support/QueryType.java
@@ -20,5 +20,5 @@ package org.apereo.services.persondir.support;
 
 public enum QueryType {
     AND,
-    OR;
+    OR
 }

--- a/person-directory-impl/src/main/java/org/apereo/services/persondir/support/SAMLCredentialPersonAttributeDao.java
+++ b/person-directory-impl/src/main/java/org/apereo/services/persondir/support/SAMLCredentialPersonAttributeDao.java
@@ -69,7 +69,7 @@ public class SAMLCredentialPersonAttributeDao extends AbstractQueryPersonAttribu
     protected List<IPersonAttributes> getPeopleForQuery(QueryBuilder queryBuilder, String queryUserName) {
 
         final String currentUserName = currentUserProvider.getCurrentUserName();
-        ;
+
         if (currentUserName == null) {
             this.logger.warn("A null name was returned by the currentUserProvider, returning null.");
             return Collections.emptyList();
@@ -104,7 +104,7 @@ public class SAMLCredentialPersonAttributeDao extends AbstractQueryPersonAttribu
                     // Marshall what we found into an (unmapped) IPersonAttributes object
                     final Map<String, List<Object>> attributes = new HashMap<>();
                     for (Attribute a : credential.getAttributes()) {
-                        List<Object> list = new ArrayList<Object>();
+                        List<Object> list = new ArrayList<>();
                         for (XMLObject xmlo : a.getAttributeValues()) {
                             String str = extractStringValue(xmlo);
                             if (str != null) {

--- a/person-directory-impl/src/main/java/org/apereo/services/persondir/support/jdbc/AbstractJdbcPersonAttributeDao.java
+++ b/person-directory-impl/src/main/java/org/apereo/services/persondir/support/jdbc/AbstractJdbcPersonAttributeDao.java
@@ -68,7 +68,7 @@ public abstract class AbstractJdbcPersonAttributeDao<R> extends AbstractQueryPer
             DEFAULT_DATA_ATTRIBUTE_CASE_CANONICALIZATION_FUNCTIONS;
 
     static {
-        DEFAULT_DATA_ATTRIBUTE_CASE_CANONICALIZATION_FUNCTIONS = new HashMap();
+        DEFAULT_DATA_ATTRIBUTE_CASE_CANONICALIZATION_FUNCTIONS = new HashMap<>();
 
         DEFAULT_DATA_ATTRIBUTE_CASE_CANONICALIZATION_FUNCTIONS.put(CaseCanonicalizationMode.LOWER, new MessageFormat("lower({0})"));
         DEFAULT_DATA_ATTRIBUTE_CASE_CANONICALIZATION_FUNCTIONS.put(CaseCanonicalizationMode.UPPER, new MessageFormat("upper({0})"));

--- a/person-directory-impl/src/main/java/org/apereo/services/persondir/support/jdbc/NamedParameterJdbcPersonAttributeDao.java
+++ b/person-directory-impl/src/main/java/org/apereo/services/persondir/support/jdbc/NamedParameterJdbcPersonAttributeDao.java
@@ -18,14 +18,15 @@
  */
 package org.apereo.services.persondir.support.jdbc;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apereo.services.persondir.IPersonAttributeDaoFilter;
 import org.apereo.services.persondir.IPersonAttributes;
 import org.apereo.services.persondir.support.AbstractDefaultAttributePersonAttributeDao;
 import org.apereo.services.persondir.support.CaseInsensitiveNamedPersonImpl;
 import org.apereo.services.persondir.support.IUsernameAttributeProvider;
 import org.apereo.services.persondir.util.CollectionsUtil;
+import org.springframework.beans.factory.BeanInitializationException;
 import org.springframework.beans.factory.InitializingBean;
-import org.springframework.beans.factory.annotation.Required;
 import org.springframework.jdbc.core.RowCallbackHandler;
 import org.springframework.jdbc.core.namedparam.AbstractSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -85,18 +86,15 @@ public class NamedParameterJdbcPersonAttributeDao extends AbstractDefaultAttribu
     private Set<String> availableQueryAttributes = null;  // default
     private Set<String> userAttributeNames = null;  // default
 
-    @Required
     public void setDataSource(final DataSource dataSource) {
         this.dataSource = dataSource;
     }
 
-    @Required
     public void setSql(final String sql) {
         this.sql = sql;
     }
 
     @Override
-    @Required
     public void setUsernameAttributeProvider(final IUsernameAttributeProvider usernameAttributeProvider) {
         this.usernameAttributeProvider = usernameAttributeProvider;
     }
@@ -105,13 +103,16 @@ public class NamedParameterJdbcPersonAttributeDao extends AbstractDefaultAttribu
         this.availableQueryAttributes = CollectionsUtil.safelyWrapAsUnmodifiableSet(availableQueryAttributes);
     }
 
-    @Required
     public void setUserAttributeNames(final Set<String> userAttributeNames) {
         this.userAttributeNames = CollectionsUtil.safelyWrapAsUnmodifiableSet(userAttributeNames);
     }
 
     @Override
     public void afterPropertiesSet() throws Exception {
+        if (dataSource == null) throw new BeanInitializationException("dataSource property is required");
+        if (StringUtils.isEmpty(sql)) throw new BeanInitializationException("sql property is required");
+        if (userAttributeNames == null) throw new BeanInitializationException("userAttributeNames property is required");
+        if (usernameAttributeProvider == null) throw new BeanInitializationException("usernameAttributeProvider is required");
         jdbcTemplate = new NamedParameterJdbcTemplate(dataSource);
     }
 

--- a/person-directory-impl/src/main/java/org/apereo/services/persondir/support/ldap/LdapPersonAttributeDao.java
+++ b/person-directory-impl/src/main/java/org/apereo/services/persondir/support/ldap/LdapPersonAttributeDao.java
@@ -142,7 +142,7 @@ public class LdapPersonAttributeDao extends AbstractQueryPersonAttributeDao<Logi
      * @see org.springframework.beans.factory.InitializingBean#afterPropertiesSet()
      */
     @Override
-    public void afterPropertiesSet() throws Exception {
+    public void afterPropertiesSet() {
         final Map<String, Set<String>> resultAttributeMapping = this.getResultAttributeMapping();
         if (this.setReturningAttributes && resultAttributeMapping != null) {
             this.searchControls.setReturningAttributes(resultAttributeMapping.keySet().toArray(new String[resultAttributeMapping.size()]));
@@ -236,26 +236,6 @@ public class LdapPersonAttributeDao extends AbstractQueryPersonAttributeDao<Logi
         }
 
         return peopleAttributes;
-    }
-
-    /**
-     * @see javax.naming.directory.SearchControls#getTimeLimit()
-     * @return time limit
-     * @deprecated Set the property on the {@link SearchControls} and set that via {@link #setSearchControls(SearchControls)}
-     */
-    @Deprecated
-    public int getTimeLimit() {
-        return this.searchControls.getTimeLimit();
-    }
-
-    /**
-     * @see javax.naming.directory.SearchControls#setTimeLimit(int)
-     * @param ms time limit in milliseconds
-     * @deprecated
-     */
-    @Deprecated
-    public void setTimeLimit(final int ms) {
-        this.searchControls.setTimeLimit(ms);
     }
 
     /**

--- a/person-directory-impl/src/main/java/org/apereo/services/persondir/support/rule/StringFormatAttributeRule.java
+++ b/person-directory-impl/src/main/java/org/apereo/services/persondir/support/rule/StringFormatAttributeRule.java
@@ -18,10 +18,12 @@
  */
 package org.apereo.services.persondir.support.rule;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apereo.services.persondir.IPersonAttributes;
 import org.apereo.services.persondir.support.IUsernameAttributeProvider;
 import org.apereo.services.persondir.support.NamedPersonImpl;
-import org.springframework.beans.factory.annotation.Required;
+import org.springframework.beans.factory.BeanInitializationException;
+import org.springframework.beans.factory.InitializingBean;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -37,14 +39,13 @@ import java.util.Set;
  *
  * @author awills
  */
-public final class StringFormatAttributeRule implements AttributeRule {
+public final class StringFormatAttributeRule implements AttributeRule, InitializingBean {
 
     private String formatString;
     private List<String> formatArguments;
     private String outputAttribute;
     private IUsernameAttributeProvider usernameAttributeProvider;
 
-    @Required
     public void setFormatString(final String formatString) {
         this.formatString = formatString;
     }
@@ -53,12 +54,10 @@ public final class StringFormatAttributeRule implements AttributeRule {
         this.formatArguments = formatArguments;
     }
 
-    @Required
     public void setOutputAttribute(final String outputAttribute) {
         this.outputAttribute = outputAttribute;
     }
 
-    @Required
     public void setUsernameAttributeProvider(final IUsernameAttributeProvider usernameAttributeProvider) {
         this.usernameAttributeProvider = usernameAttributeProvider;
     }
@@ -126,4 +125,10 @@ public final class StringFormatAttributeRule implements AttributeRule {
         return Collections.singleton(outputAttribute);
     }
 
+    @Override
+    public void afterPropertiesSet() {
+        if (StringUtils.isEmpty(formatString)) throw new BeanInitializationException("formatString is required");
+        if (usernameAttributeProvider == null) throw new BeanInitializationException("usernameAttributeProvider is required");
+        if (outputAttribute == null) throw new BeanInitializationException("outputAttribute is required");
+    }
 }

--- a/person-directory-impl/src/main/java/org/apereo/services/persondir/support/web/RequestAttributeSourceFilter.java
+++ b/person-directory-impl/src/main/java/org/apereo/services/persondir/support/web/RequestAttributeSourceFilter.java
@@ -65,7 +65,7 @@ public class RequestAttributeSourceFilter extends GenericFilterBean {
     public enum ProcessingPosition {
         PRE,
         POST,
-        BOTH;
+        BOTH
     }
 
     private String usernameAttribute;

--- a/person-directory-impl/src/test/java/org/apereo/services/persondir/AbstractPersonAttributeDaoTest.java
+++ b/person-directory-impl/src/test/java/org/apereo/services/persondir/AbstractPersonAttributeDaoTest.java
@@ -75,12 +75,12 @@ public abstract class AbstractPersonAttributeDaoTest extends TestCase {
         final IPersonAttributeDao dao = getPersonAttributeDaoInstance();
         final Map<String, List<Object>> nullMap = null;
         try {
-            dao.getMultivaluedUserAttributes(nullMap, IPersonAttributeDaoFilter.alwaysChoose());
+            dao.getPeopleWithMultivaluedAttributes(nullMap, IPersonAttributeDaoFilter.alwaysChoose());
         } catch (final RuntimeException iae) {
             // good, as expected
             return;
         }
-        fail("Expected IllegalArgumentException on getMultivaluedUserAttributes((Map)null)");
+        fail("Expected IllegalArgumentException or NullPointerException on getMultivaluedUserAttributes((Map)null)");
 
     }
 
@@ -93,7 +93,7 @@ public abstract class AbstractPersonAttributeDaoTest extends TestCase {
         final IPersonAttributeDao dao = getPersonAttributeDaoInstance();
         final Map<String, Object> nullMap = null;
         try {
-            dao.getUserAttributes(nullMap, IPersonAttributeDaoFilter.alwaysChoose());
+            dao.getPeople(nullMap, IPersonAttributeDaoFilter.alwaysChoose());
         } catch (final NullPointerException iae) {
             // good, as expected
             return;
@@ -111,7 +111,7 @@ public abstract class AbstractPersonAttributeDaoTest extends TestCase {
         final IPersonAttributeDao dao = getPersonAttributeDaoInstance();
         final String nullString = null;
         try {
-            dao.getMultivaluedUserAttributes(nullString, IPersonAttributeDaoFilter.alwaysChoose());
+            dao.getPerson(nullString, IPersonAttributeDaoFilter.alwaysChoose());
         } catch (final RuntimeException iae) {
             // good, as expected
             return;
@@ -128,7 +128,7 @@ public abstract class AbstractPersonAttributeDaoTest extends TestCase {
         final IPersonAttributeDao dao = getPersonAttributeDaoInstance();
         final String nullString = null;
         try {
-            dao.getUserAttributes(nullString, IPersonAttributeDaoFilter.alwaysChoose());
+            dao.getPerson(nullString, IPersonAttributeDaoFilter.alwaysChoose());
         } catch (final RuntimeException iae) {
             // good, as expected
             return;

--- a/person-directory-impl/src/test/java/org/apereo/services/persondir/mock/ThrowingPersonAttributeDao.java
+++ b/person-directory-impl/src/test/java/org/apereo/services/persondir/mock/ThrowingPersonAttributeDao.java
@@ -68,8 +68,4 @@ public class ThrowingPersonAttributeDao extends BasePersonAttributeDao {
         throw new RuntimeException("ThrowingPersonAttributeDao always throws");
     }
 
-    @Override
-    protected Map<String, Object> flattenResults(final Map<String, List<Object>> multivaluedUserAttributes) {
-        throw new RuntimeException("ThrowingPersonAttributeDao always throws");
-    }
 }

--- a/person-directory-impl/src/test/java/org/apereo/services/persondir/support/AbstractDefaultQueryPersonAttributeDaoTest.java
+++ b/person-directory-impl/src/test/java/org/apereo/services/persondir/support/AbstractDefaultQueryPersonAttributeDaoTest.java
@@ -63,7 +63,7 @@ public abstract class AbstractDefaultQueryPersonAttributeDaoTest extends Abstrac
         final Map<String, List<Object>> expected = new HashMap<>();
         expected.put("TestAttrName", Util.list("edalquist"));
 
-        assertEquals(expected, dao.getMultivaluedUserAttributes("edalquist", IPersonAttributeDaoFilter.alwaysChoose()));
+        assertEquals(expected, dao.getPerson("edalquist", IPersonAttributeDaoFilter.alwaysChoose()).getAttributes());
     }
 
     private static class SimpleDefaultQueryPersonAttributeDao extends AbstractDefaultAttributePersonAttributeDao {

--- a/person-directory-impl/src/test/java/org/apereo/services/persondir/support/AbstractFlatteningPersonAttributeDaoTest.java
+++ b/person-directory-impl/src/test/java/org/apereo/services/persondir/support/AbstractFlatteningPersonAttributeDaoTest.java
@@ -21,12 +21,14 @@ package org.apereo.services.persondir.support;
 import org.apereo.services.persondir.IPersonAttributeDao;
 import org.apereo.services.persondir.AbstractPersonAttributeDaoTest;
 import org.apereo.services.persondir.IPersonAttributeDaoFilter;
+import org.apereo.services.persondir.IPersonAttributes;
 import org.apereo.services.persondir.util.Util;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 
 /**
@@ -51,22 +53,22 @@ public abstract class AbstractFlatteningPersonAttributeDaoTest extends AbstractP
         backingMap.put("address", Collections.emptyList());
 
         final Map<String, Object> expected = new HashMap<>();
-        expected.put("name", "edalquist");
-        expected.put("emails", "edalquist@foo.com");
-        expected.put("phone", null);
+        expected.put("name", Util.list("edalquist"));
+        expected.put("emails", Util.list("edalquist@foo.com", "ebd@none.org"));
+        expected.put("phone", Util.list((Object) null));
         expected.put("title", null);
-        expected.put("address", null);
+        expected.put("address", Collections.emptyList());
 
 
 //        final SimpleDefaultQueryPersonAttributeDao flatteningPersonAttributeDao = new SimpleDefaultQueryPersonAttributeDao(backingMap);
         final StubPersonAttributeDao flatteningPersonAttributeDao = new StubPersonAttributeDao(backingMap);
 
-        final Map<String, Object> userAttributesUid = flatteningPersonAttributeDao.getUserAttributes("seed", IPersonAttributeDaoFilter.alwaysChoose());
-        assertEquals(expected, userAttributesUid);
+        final IPersonAttributes userAttributesUid = flatteningPersonAttributeDao.getPerson("seed", IPersonAttributeDaoFilter.alwaysChoose());
+        assertEquals(expected, userAttributesUid.getAttributes());
 
-        final Map<String, Object> userAttributesMap = flatteningPersonAttributeDao.getUserAttributes(Collections.singletonMap("key", new Object()),
+        final Set<IPersonAttributes> userAttributesSet = flatteningPersonAttributeDao.getPeople(Collections.singletonMap("key", new Object()),
             IPersonAttributeDaoFilter.alwaysChoose());
-        assertEquals(expected, userAttributesMap);
+        assertEquals(expected, userAttributesSet.iterator().next().getAttributes());
     }
 
 //

--- a/person-directory-impl/src/test/java/org/apereo/services/persondir/support/AbstractQueryPersonAttributeDaoTest.java
+++ b/person-directory-impl/src/test/java/org/apereo/services/persondir/support/AbstractQueryPersonAttributeDaoTest.java
@@ -62,7 +62,7 @@ public class AbstractQueryPersonAttributeDaoTest extends AbstractPersonAttribute
     }
 
     public void testDefaultAttributeNameUsage() {
-        this.testQueryPersonAttributeDao.getUserAttributes("eric", IPersonAttributeDaoFilter.alwaysChoose());
+        this.testQueryPersonAttributeDao.getPerson("eric", IPersonAttributeDaoFilter.alwaysChoose());
         final List<List<Object>> args = this.testQueryPersonAttributeDao.getArgs();
 
         //Do asList for an easy comparison
@@ -70,12 +70,12 @@ public class AbstractQueryPersonAttributeDaoTest extends AbstractPersonAttribute
     }
 
     public void testNoQueryAttributeMapping() {
-        this.testQueryPersonAttributeDao.getUserAttributes("eric", IPersonAttributeDaoFilter.alwaysChoose());
+        this.testQueryPersonAttributeDao.getPerson("eric", IPersonAttributeDaoFilter.alwaysChoose());
         final List<List<Object>> args1 = this.testQueryPersonAttributeDao.getArgs();
         assertEquals(Arrays.asList(Arrays.asList("eric")), args1);
 
         this.testQueryPersonAttributeDao.setUseAllQueryAttributes(false);
-        this.testQueryPersonAttributeDao.getUserAttributes("eric", IPersonAttributeDaoFilter.alwaysChoose());
+        this.testQueryPersonAttributeDao.getPerson("eric", IPersonAttributeDaoFilter.alwaysChoose());
         final List<List<Object>> args2 = this.testQueryPersonAttributeDao.getArgs();
         assertNull(args2);
     }
@@ -85,7 +85,7 @@ public class AbstractQueryPersonAttributeDaoTest extends AbstractPersonAttribute
         queryAttributes.put("userid", null);
 
         this.testQueryPersonAttributeDao.setQueryAttributeMapping(queryAttributes);
-        this.testQueryPersonAttributeDao.getUserAttributes("eric", IPersonAttributeDaoFilter.alwaysChoose());
+        this.testQueryPersonAttributeDao.getPerson("eric", IPersonAttributeDaoFilter.alwaysChoose());
         final List<List<Object>> args = this.testQueryPersonAttributeDao.getArgs();
         assertNull(args);
     }
@@ -97,9 +97,9 @@ public class AbstractQueryPersonAttributeDaoTest extends AbstractPersonAttribute
         this.testQueryPersonAttributeDao.setQueryAttributeMapping(queryAttributes);
 
         final Map<String, List<Object>> seed = new HashMap<>();
-        seed.put("name.first", Collections.singletonList((Object) "eric"));
-        seed.put("name.last", Collections.singletonList((Object) "dalquist"));
-        this.testQueryPersonAttributeDao.getMultivaluedUserAttributes(seed, IPersonAttributeDaoFilter.alwaysChoose());
+        seed.put("name.first", Collections.singletonList("eric"));
+        seed.put("name.last", Collections.singletonList("dalquist"));
+        this.testQueryPersonAttributeDao.getPeopleWithMultivaluedAttributes(seed, IPersonAttributeDaoFilter.alwaysChoose());
         final List<List<Object>> args = this.testQueryPersonAttributeDao.getArgs();
         final Object[] expectedArgs = new Object[]{Collections.singletonList("eric"), Collections.singletonList("dalquist")};
 
@@ -116,7 +116,7 @@ public class AbstractQueryPersonAttributeDaoTest extends AbstractPersonAttribute
         final InMemoryAbstractQueryPersonAttributeDao dao = new InMemoryAbstractQueryPersonAttributeDao(storedAttrs);
 
         final Map<String, List<Object>> seed = new HashMap<>();
-        seed.put("username", Collections.singletonList((Object) "edalquist"));
+        seed.put("username", Collections.singletonList("edalquist"));
 
         final Set<IPersonAttributes> allResults = dao.getPeopleWithMultivaluedAttributes(seed,
             IPersonAttributeDaoFilter.alwaysChoose());
@@ -144,7 +144,7 @@ public class AbstractQueryPersonAttributeDaoTest extends AbstractPersonAttribute
         dao.setResultAttributeMapping(resultAttributeMappings);
 
         final Map<String, List<Object>> seed = new HashMap<>();
-        seed.put("username", Collections.singletonList((Object) "edalquist"));
+        seed.put("username", Collections.singletonList("edalquist"));
 
         final Set<IPersonAttributes> allResults = dao.getPeopleWithMultivaluedAttributes(seed,
             IPersonAttributeDaoFilter.alwaysChoose());
@@ -172,7 +172,7 @@ public class AbstractQueryPersonAttributeDaoTest extends AbstractPersonAttribute
         dao.setCaseInsensitiveResultAttributes(caseInsensitiveAttributes);
 
         final Map<String, List<Object>> seed = new HashMap<>();
-        seed.put("username", Collections.singletonList((Object) "edalquist"));
+        seed.put("username", Collections.singletonList("edalquist"));
 
         final Set<IPersonAttributes> allResults = dao.getPeopleWithMultivaluedAttributes(seed,
             IPersonAttributeDaoFilter.alwaysChoose());
@@ -203,7 +203,7 @@ public class AbstractQueryPersonAttributeDaoTest extends AbstractPersonAttribute
         dao.setResultAttributeMapping(resultAttributeMappings);
 
         final Map<String, List<Object>> seed = new HashMap<>();
-        seed.put("username", Collections.singletonList((Object) "edalquist"));
+        seed.put("username", Collections.singletonList("edalquist"));
 
         final Set<IPersonAttributes> allResults = dao.getPeopleWithMultivaluedAttributes(seed,
             IPersonAttributeDaoFilter.alwaysChoose());
@@ -239,7 +239,7 @@ public class AbstractQueryPersonAttributeDaoTest extends AbstractPersonAttribute
         dao.setUsernameCaseCanonicalizationMode(CaseCanonicalizationMode.LOWER);
 
         final Map<String, List<Object>> seed = new HashMap<>();
-        seed.put("username", Collections.singletonList((Object) "edalquist"));
+        seed.put("username", Collections.singletonList("edalquist"));
 
         final Set<IPersonAttributes> allResults = dao.getPeopleWithMultivaluedAttributes(seed,
             IPersonAttributeDaoFilter.alwaysChoose());
@@ -269,7 +269,7 @@ public class AbstractQueryPersonAttributeDaoTest extends AbstractPersonAttribute
         // Intentionally *not* calling setUsernameCaseCanonicalizationMode()
 
         final Map<String, List<Object>> seed = new HashMap<>();
-        seed.put("username", Collections.singletonList((Object) "edalquist"));
+        seed.put("username", Collections.singletonList("edalquist"));
 
         final Set<IPersonAttributes> allResults = dao.getPeopleWithMultivaluedAttributes(seed,
             IPersonAttributeDaoFilter.alwaysChoose());
@@ -299,7 +299,7 @@ public class AbstractQueryPersonAttributeDaoTest extends AbstractPersonAttribute
 
         @Override
         protected List<IPersonAttributes> getPeopleForQuery(final List<List<Object>> queryBuilder, final String queryUserName) {
-            return new ArrayList(storage.getPeopleWithMultivaluedAttributes(new HashMap<String, List<Object>>(),
+            return new ArrayList<>(storage.getPeopleWithMultivaluedAttributes(new HashMap<String, List<Object>>(),
                 IPersonAttributeDaoFilter.alwaysChoose()));
         }
 

--- a/person-directory-impl/src/test/java/org/apereo/services/persondir/support/AttributeBasedCacheKeyGeneratorTest.java
+++ b/person-directory-impl/src/test/java/org/apereo/services/persondir/support/AttributeBasedCacheKeyGeneratorTest.java
@@ -58,7 +58,7 @@ public class AttributeBasedCacheKeyGeneratorTest {
         assertEquals(0, cacheProviderFacade.getRemoveCount());
 
         //Should be a miss
-        personAttributeDao.getMultivaluedUserAttributes("edalquist", IPersonAttributeDaoFilter.alwaysChoose());
+        personAttributeDao.getPerson("edalquist", IPersonAttributeDaoFilter.alwaysChoose());
         assertEquals(1, cacheProviderFacade.getCacheSize());
         assertEquals(0, cacheProviderFacade.getFlushCount());
         assertEquals(0, cacheProviderFacade.getHitCount());
@@ -67,7 +67,7 @@ public class AttributeBasedCacheKeyGeneratorTest {
         assertEquals(0, cacheProviderFacade.getRemoveCount());
 
         //Should be a hit
-        personAttributeDao.getMultivaluedUserAttributes("edalquist", IPersonAttributeDaoFilter.alwaysChoose());
+        personAttributeDao.getPerson("edalquist", IPersonAttributeDaoFilter.alwaysChoose());
         assertEquals(1, cacheProviderFacade.getCacheSize());
         assertEquals(0, cacheProviderFacade.getFlushCount());
         assertEquals(1, cacheProviderFacade.getHitCount());
@@ -75,18 +75,19 @@ public class AttributeBasedCacheKeyGeneratorTest {
         assertEquals(1, cacheProviderFacade.getPutCount());
         assertEquals(0, cacheProviderFacade.getRemoveCount());
 
-        //Should be a hit
-        personAttributeDao.getMultivaluedUserAttributes(Collections.singletonMap("userName", Collections.singletonList((Object) "edalquist"))
+        // Should be a miss b/c we can't cache single IPersonAttributes and Set<IPersonAttributes> with same key
+        // method name added to key to avoid caching across methods
+        personAttributeDao.getPeopleWithMultivaluedAttributes(Collections.singletonMap("userName", Collections.singletonList("edalquist"))
             , IPersonAttributeDaoFilter.alwaysChoose());
-        assertEquals(1, cacheProviderFacade.getCacheSize());
+        assertEquals(2, cacheProviderFacade.getCacheSize());
         assertEquals(0, cacheProviderFacade.getFlushCount());
-        assertEquals(2, cacheProviderFacade.getHitCount());
-        assertEquals(1, cacheProviderFacade.getMissCount());
-        assertEquals(1, cacheProviderFacade.getPutCount());
+        assertEquals(1, cacheProviderFacade.getHitCount());
+        assertEquals(2, cacheProviderFacade.getMissCount());
+        assertEquals(2, cacheProviderFacade.getPutCount());
         assertEquals(0, cacheProviderFacade.getRemoveCount());
 
-        //Should be a miss
-        personAttributeDao.getUserAttributes("edalquist", IPersonAttributeDaoFilter.alwaysChoose());
+        //Should be a hit
+        personAttributeDao.getPerson("edalquist", IPersonAttributeDaoFilter.alwaysChoose());
         assertEquals(2, cacheProviderFacade.getCacheSize());
         assertEquals(0, cacheProviderFacade.getFlushCount());
         assertEquals(2, cacheProviderFacade.getHitCount());
@@ -95,7 +96,7 @@ public class AttributeBasedCacheKeyGeneratorTest {
         assertEquals(0, cacheProviderFacade.getRemoveCount());
 
         //Should be a hit
-        personAttributeDao.getUserAttributes("edalquist", IPersonAttributeDaoFilter.alwaysChoose());
+        personAttributeDao.getPerson("edalquist", IPersonAttributeDaoFilter.alwaysChoose());
         assertEquals(2, cacheProviderFacade.getCacheSize());
         assertEquals(0, cacheProviderFacade.getFlushCount());
         assertEquals(3, cacheProviderFacade.getHitCount());
@@ -103,32 +104,32 @@ public class AttributeBasedCacheKeyGeneratorTest {
         assertEquals(2, cacheProviderFacade.getPutCount());
         assertEquals(0, cacheProviderFacade.getRemoveCount());
 
-        //Should be a hit
-        personAttributeDao.getUserAttributes(Collections.singletonMap("userName", (Object) "edalquist")
+        //Should be a miss
+        personAttributeDao.getPeople(Collections.singletonMap("userName", "edalquist")
             , IPersonAttributeDaoFilter.alwaysChoose());
-        assertEquals(2, cacheProviderFacade.getCacheSize());
+        assertEquals(3, cacheProviderFacade.getCacheSize());
         assertEquals(0, cacheProviderFacade.getFlushCount());
-        assertEquals(4, cacheProviderFacade.getHitCount());
-        assertEquals(2, cacheProviderFacade.getMissCount());
-        assertEquals(2, cacheProviderFacade.getPutCount());
+        assertEquals(3, cacheProviderFacade.getHitCount());
+        assertEquals(3, cacheProviderFacade.getMissCount());
+        assertEquals(3, cacheProviderFacade.getPutCount());
         assertEquals(0, cacheProviderFacade.getRemoveCount());
 
         //Should miss
         personAttributeDao.getPossibleUserAttributeNames(IPersonAttributeDaoFilter.alwaysChoose());
-        assertEquals(3, cacheProviderFacade.getCacheSize());
+        assertEquals(4, cacheProviderFacade.getCacheSize());
         assertEquals(0, cacheProviderFacade.getFlushCount());
-        assertEquals(4, cacheProviderFacade.getHitCount());
-        assertEquals(3, cacheProviderFacade.getMissCount());
-        assertEquals(3, cacheProviderFacade.getPutCount());
+        assertEquals(3, cacheProviderFacade.getHitCount());
+        assertEquals(4, cacheProviderFacade.getMissCount());
+        assertEquals(4, cacheProviderFacade.getPutCount());
         assertEquals(0, cacheProviderFacade.getRemoveCount());
 
         //Should hit
         personAttributeDao.getPossibleUserAttributeNames(IPersonAttributeDaoFilter.alwaysChoose());
-        assertEquals(3, cacheProviderFacade.getCacheSize());
+        assertEquals(4, cacheProviderFacade.getCacheSize());
         assertEquals(0, cacheProviderFacade.getFlushCount());
-        assertEquals(5, cacheProviderFacade.getHitCount());
-        assertEquals(3, cacheProviderFacade.getMissCount());
-        assertEquals(3, cacheProviderFacade.getPutCount());
+        assertEquals(4, cacheProviderFacade.getHitCount());
+        assertEquals(4, cacheProviderFacade.getMissCount());
+        assertEquals(4, cacheProviderFacade.getPutCount());
         assertEquals(0, cacheProviderFacade.getRemoveCount());
     }
 }

--- a/person-directory-impl/src/test/java/org/apereo/services/persondir/support/CascadingPersonAttributeDaoTest.java
+++ b/person-directory-impl/src/test/java/org/apereo/services/persondir/support/CascadingPersonAttributeDaoTest.java
@@ -20,6 +20,7 @@ package org.apereo.services.persondir.support;
 
 import org.apereo.services.persondir.IPersonAttributeDao;
 import org.apereo.services.persondir.IPersonAttributeDaoFilter;
+import org.apereo.services.persondir.IPersonAttributes;
 import org.apereo.services.persondir.mock.ThrowingPersonAttributeDao;
 import org.apereo.services.persondir.support.merger.MultivaluedAttributeMerger;
 import org.apereo.services.persondir.util.Util;
@@ -106,7 +107,7 @@ public class CascadingPersonAttributeDaoTest
         targetDao.setPersonAttributeDaos(targets);
         targetDao.setMerger(new MultivaluedAttributeMerger());
 
-        final Map<String, List<Object>> results = targetDao.getMultivaluedUserAttributes("edalquist", IPersonAttributeDaoFilter.alwaysChoose());
+        final IPersonAttributes results = targetDao.getPerson("edalquist", IPersonAttributeDaoFilter.alwaysChoose());
 
         final Map<String, List<Object>> expected = new HashMap<>();
         expected.put("username", Util.list("edalquist"));
@@ -114,14 +115,14 @@ public class CascadingPersonAttributeDaoTest
         expected.put("major", Util.list("CS"));
         expected.put("phone", Util.list("777-7777", "777-7777x777"));
 
-        assertEquals(expected, results);
+        assertEquals(expected, results.getAttributes());
     }
 
     public void testNoChildren() {
         final CascadingPersonAttributeDao targetDao = new CascadingPersonAttributeDao();
 
         try {
-            targetDao.getMultivaluedUserAttributes("edalquist", IPersonAttributeDaoFilter.alwaysChoose());
+            targetDao.getPerson("edalquist", IPersonAttributeDaoFilter.alwaysChoose());
             fail("IllegalStateException should have been thrown with no child DAOs");
         } catch (final IllegalStateException ise) {
             //expected
@@ -140,7 +141,7 @@ public class CascadingPersonAttributeDaoTest
 
 
         targetDao.setRecoverExceptions(true);
-        final Map<String, List<Object>> results = targetDao.getMultivaluedUserAttributes("edalquist",
+        final IPersonAttributes results = targetDao.getPerson("edalquist",
             IPersonAttributeDaoFilter.alwaysChoose());
 
         final Map<String, List<Object>> expected = new HashMap<>();
@@ -149,12 +150,12 @@ public class CascadingPersonAttributeDaoTest
         expected.put("username", Util.list("edalquist"));
         expected.put("phone", Util.list("777-7777", "777-7777x777"));
 
-        assertEquals(expected, results);
+        assertEquals(expected, results.getAttributes());
 
 
         targetDao.setRecoverExceptions(false);
         try {
-            targetDao.getMultivaluedUserAttributes("edalquist", IPersonAttributeDaoFilter.alwaysChoose());
+            targetDao.getPerson("edalquist", IPersonAttributeDaoFilter.alwaysChoose());
             fail("RuntimeException should have been thrown with no child DAOs");
         } catch (final RuntimeException ise) {
             //expected
@@ -171,7 +172,7 @@ public class CascadingPersonAttributeDaoTest
         targetDao.setPersonAttributeDaos(targets);
         targetDao.setMerger(new MultivaluedAttributeMerger());
 
-        final Map<String, List<Object>> results = targetDao.getMultivaluedUserAttributes("edalquist",
+        final IPersonAttributes results = targetDao.getPerson("edalquist",
             IPersonAttributeDaoFilter.alwaysChoose());
 
         final Map<String, List<Object>> expected = new HashMap<>();
@@ -180,7 +181,7 @@ public class CascadingPersonAttributeDaoTest
         expected.put("major", Util.list("CS"));
         expected.put("phone", Util.list("777-7777", "777-7777x777"));
 
-        assertEquals(expected, results);
+        assertEquals(expected, results.getAttributes());
     }
 
     public void testNullFirstResultStop() {
@@ -194,7 +195,7 @@ public class CascadingPersonAttributeDaoTest
         targetDao.setPersonAttributeDaos(targets);
         targetDao.setMerger(new MultivaluedAttributeMerger());
 
-        final Map<String, List<Object>> results = targetDao.getMultivaluedUserAttributes("edalquist",
+        final IPersonAttributes results = targetDao.getPerson("edalquist",
             IPersonAttributeDaoFilter.alwaysChoose());
 
         assertNull(results);

--- a/person-directory-impl/src/test/java/org/apereo/services/persondir/support/ComplexStubPersonAttributeDaoTest.java
+++ b/person-directory-impl/src/test/java/org/apereo/services/persondir/support/ComplexStubPersonAttributeDaoTest.java
@@ -19,6 +19,7 @@
 package org.apereo.services.persondir.support;
 
 import org.apereo.services.persondir.IPersonAttributeDaoFilter;
+import org.apereo.services.persondir.IPersonAttributes;
 import org.apereo.services.persondir.util.Util;
 
 import java.util.HashMap;
@@ -97,21 +98,24 @@ public class ComplexStubPersonAttributeDaoTest
     public void testGetUserAttributesMap() {
         final Map<String, List<Object>> awp9Key = new HashMap<>();
         awp9Key.put("username", Util.list("awp9"));
-        assertEquals(this.backingMap.get("awp9"), this.testInstance.getMultivaluedUserAttributes(awp9Key, IPersonAttributeDaoFilter.alwaysChoose()));
+        Set<IPersonAttributes> resultSet = this.testInstance.getPeopleWithMultivaluedAttributes(awp9Key, IPersonAttributeDaoFilter.alwaysChoose());
+        assertEquals(this.backingMap.get("awp9"), resultSet.iterator().next().getAttributes());
 
         final Map<String, List<Object>> unknownUserKey = new HashMap<>();
         unknownUserKey.put("uid", Util.list("unknownUser"));
 
-        assertNull(this.testInstance.getMultivaluedUserAttributes(unknownUserKey, IPersonAttributeDaoFilter.alwaysChoose()));
+        assertNull(this.testInstance.getPeopleWithMultivaluedAttributes(unknownUserKey, IPersonAttributeDaoFilter.alwaysChoose()));
     }
 
     /**
      * Test getting user attributes using a String key.
      */
     public void testGetUserAttributesString() {
-        assertEquals(this.backingMap.get("aam26"), this.testInstance.getMultivaluedUserAttributes("aam26", IPersonAttributeDaoFilter.alwaysChoose()));
+        IPersonAttributes result = this.testInstance.getPerson("aam26", IPersonAttributeDaoFilter.alwaysChoose());
+        assertNotNull(result);
+        assertEquals(this.backingMap.get("aam26"), result.getAttributes());
 
-        assertNull(this.testInstance.getMultivaluedUserAttributes("unknownUser", IPersonAttributeDaoFilter.alwaysChoose()));
+        assertNull(this.testInstance.getPerson("unknownUser", IPersonAttributeDaoFilter.alwaysChoose()));
     }
 
     @Override

--- a/person-directory-impl/src/test/java/org/apereo/services/persondir/support/EchoPersonAttributeDaoImplTest.java
+++ b/person-directory-impl/src/test/java/org/apereo/services/persondir/support/EchoPersonAttributeDaoImplTest.java
@@ -21,11 +21,13 @@ package org.apereo.services.persondir.support;
 import org.apereo.services.persondir.AbstractPersonAttributeDaoTest;
 import org.apereo.services.persondir.IPersonAttributeDao;
 import org.apereo.services.persondir.IPersonAttributeDaoFilter;
+import org.apereo.services.persondir.IPersonAttributes;
 import org.apereo.services.persondir.util.Util;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * @author Eric Dalquist
@@ -45,11 +47,11 @@ public class EchoPersonAttributeDaoImplTest extends AbstractPersonAttributeDaoTe
         testMap.put("key1", Util.list("val1"));
         testMap.put("key2", Util.list("val2"));
 
-        final Map<String, List<Object>> goalMap = new HashMap<>(testMap);
+        final Map<String, Object> goalMap = new HashMap<>(testMap);
 
-        final Map<String, List<Object>> resultMap = dao.getMultivaluedUserAttributes(testMap, IPersonAttributeDaoFilter.alwaysChoose());
+        final Set<IPersonAttributes> resultSet = dao.getPeopleWithMultivaluedAttributes(testMap, IPersonAttributeDaoFilter.alwaysChoose());
 
-        assertEquals(goalMap, resultMap);
+        assertEquals(goalMap, resultSet.iterator().next().getAttributes());
     }
 
 }

--- a/person-directory-impl/src/test/java/org/apereo/services/persondir/support/GroovyPersonAttributeDaoTest.java
+++ b/person-directory-impl/src/test/java/org/apereo/services/persondir/support/GroovyPersonAttributeDaoTest.java
@@ -66,7 +66,7 @@ public class GroovyPersonAttributeDaoTest extends AbstractPersonAttributeDaoTest
             final IPersonAttributeScriptDao groovyObject = (IPersonAttributeScriptDao) groovyClass.newInstance();
             return groovyObject;
         } catch (IOException e) {
-            logger.error("Unable to load groovy file {} ", e);
+            logger.error("Unable to load groovy file {} ", filename, e);
         } catch (InstantiationException e) {
             logger.error("Unable to instantiate groovy class specified in file {}", filename, e);
         } catch (IllegalAccessException e) {
@@ -79,7 +79,11 @@ public class GroovyPersonAttributeDaoTest extends AbstractPersonAttributeDaoTest
     @Override
     @After
     public void tearDown() {
-        IOUtils.closeQuietly(loader);
+        try {
+            if (loader != null) loader.close();
+        } catch (IOException e) {
+            logger.debug("Error closing groovy classloader");
+        }
     }
 
     @Test
@@ -93,8 +97,8 @@ public class GroovyPersonAttributeDaoTest extends AbstractPersonAttributeDaoTest
     @Test
     public void testGetPeopleWithMultivaluedAttributes() {
         final Set<IPersonAttributes> results = dao.getPeopleWithMultivaluedAttributes(items, IPersonAttributeDaoFilter.alwaysChoose());
-        assertTrue("script did not add one attribute to passed-in attribute list",
-                results.iterator().next().getAttributes().size() == items.size() + 1);
+        assertEquals("script did not add one attribute to passed-in attribute list",
+            items.size() + 1, results.iterator().next().getAttributes().size());
     }
 
     @Test

--- a/person-directory-impl/src/test/java/org/apereo/services/persondir/support/MergingPersonAttributeDaoImplTest.java
+++ b/person-directory-impl/src/test/java/org/apereo/services/persondir/support/MergingPersonAttributeDaoImplTest.java
@@ -126,8 +126,8 @@ public class MergingPersonAttributeDaoImplTest
         final Map<String, List<Object>> queryMap = new HashMap<>();
         queryMap.put(queryAttr, Util.list("awp9"));
 
-        final Map<String, List<Object>> result = impl.getMultivaluedUserAttributes(queryMap, IPersonAttributeDaoFilter.alwaysChoose());
-        assertEquals(this.oneAndTwo, result);
+        final Set<IPersonAttributes> result = impl.getPeopleWithMultivaluedAttributes(queryMap, IPersonAttributeDaoFilter.alwaysChoose());
+        assertEquals(this.oneAndTwo, result.iterator().next().getAttributes());
     }
 
     /**
@@ -165,8 +165,8 @@ public class MergingPersonAttributeDaoImplTest
         final Map<String, List<Object>> queryMap = new HashMap<>();
         queryMap.put(queryAttr, Util.list("awp9"));
 
-        final Map<String, List<Object>> result = impl.getMultivaluedUserAttributes(queryMap, IPersonAttributeDaoFilter.alwaysChoose());
-        assertEquals(this.oneAndTwoAndThree, result);
+        final Set<IPersonAttributes> result = impl.getPeopleWithMultivaluedAttributes(queryMap, IPersonAttributeDaoFilter.alwaysChoose());
+        assertEquals(this.oneAndTwoAndThree, result.iterator().next().getAttributes());
     }
 
     /**
@@ -214,7 +214,7 @@ public class MergingPersonAttributeDaoImplTest
             final Map<String, List<Object>> queryMap = new HashMap<>();
             queryMap.put(queryAttr, Util.list("awp9"));
 
-            impl.getMultivaluedUserAttributes(queryMap, IPersonAttributeDaoFilter.alwaysChoose());
+            impl.getPeopleWithMultivaluedAttributes(queryMap, IPersonAttributeDaoFilter.alwaysChoose());
         } catch (final RuntimeException rte) {
             // good, was propogated
             return;
@@ -240,8 +240,8 @@ public class MergingPersonAttributeDaoImplTest
         final Map<String, List<Object>> queryMap = new HashMap<>();
         queryMap.put(queryAttr, Util.list("awp9"));
 
-        final Map<String, List<Object>> result = impl.getMultivaluedUserAttributes(queryMap, IPersonAttributeDaoFilter.alwaysChoose());
-        assertEquals(this.oneAndTwo, result);
+        final Set<IPersonAttributes> result = impl.getPeopleWithMultivaluedAttributes(queryMap, IPersonAttributeDaoFilter.alwaysChoose());
+        assertEquals(this.oneAndTwo, result.iterator().next().getAttributes());
     }
 
     public void testNoChildDaos() {
@@ -250,7 +250,7 @@ public class MergingPersonAttributeDaoImplTest
         queryMap.put(queryAttr, Util.list("awp9"));
 
         try {
-            impl.getMultivaluedUserAttributes(queryMap, IPersonAttributeDaoFilter.alwaysChoose());
+            impl.getPeopleWithMultivaluedAttributes(queryMap, IPersonAttributeDaoFilter.alwaysChoose());
             fail("IllegalStateException should have been thrown");
         } catch (final IllegalStateException ise) {
         }

--- a/person-directory-impl/src/test/java/org/apereo/services/persondir/support/MessageFormatPersonAttributeDaoTest.java
+++ b/person-directory-impl/src/test/java/org/apereo/services/persondir/support/MessageFormatPersonAttributeDaoTest.java
@@ -21,6 +21,7 @@ package org.apereo.services.persondir.support;
 import org.apereo.services.persondir.AbstractPersonAttributeDaoTest;
 import org.apereo.services.persondir.IPersonAttributeDao;
 import org.apereo.services.persondir.IPersonAttributeDaoFilter;
+import org.apereo.services.persondir.IPersonAttributes;
 import org.apereo.services.persondir.util.Util;
 
 import java.util.HashSet;
@@ -59,14 +60,14 @@ public class MessageFormatPersonAttributeDaoTest extends AbstractPersonAttribute
         query.put("firstName", Util.list("Eric"));
         query.put("lastName", Util.list("Dalquist"));
 
-        final Map<String, List<Object>> result = messageFormatPersonAttributeDao.getMultivaluedUserAttributes(query,
+        final Set<IPersonAttributes> result = messageFormatPersonAttributeDao.getPeopleWithMultivaluedAttributes(query,
             IPersonAttributeDaoFilter.alwaysChoose());
 
 
         final Map<String, List<Object>> expectedResult = new LinkedHashMap<>();
         expectedResult.put("displayName", Util.list("Eric Dalquist"));
 
-        assertEquals(expectedResult, result);
+        assertEquals(expectedResult, result.iterator().next().getAttributes());
     }
 
 

--- a/person-directory-impl/src/test/java/org/apereo/services/persondir/support/MultivaluedPersonAttributeUtilsTest.java
+++ b/person-directory-impl/src/test/java/org/apereo/services/persondir/support/MultivaluedPersonAttributeUtilsTest.java
@@ -103,7 +103,7 @@ public class MultivaluedPersonAttributeUtilsTest extends TestCase {
 
         final Set<Object> badSet = new HashSet<>();
         badSet.add("goodString");
-        badSet.add(new Long(1234));
+        badSet.add(1234L);
         badSet.add("anotherGoodString");
 
         nullKeyMap.put("wombat", badSet);
@@ -200,7 +200,7 @@ public class MultivaluedPersonAttributeUtilsTest extends TestCase {
      * Test that attempting to add a result with a null value yields no change.
      */
     public void testAddResultNullValue() {
-        final Map<String, List<String>> immutableMap = CollectionsUtil.safelyWrapAsUnmodifiableMap(new HashMap<String, List<String>>());
+        final Map<String, List<String>> immutableMap = CollectionsUtil.safelyWrapAsUnmodifiableMap(new HashMap<>());
         MultivaluedPersonAttributeUtils.addResult(immutableMap, "key", null);
     }
 

--- a/person-directory-impl/src/test/java/org/apereo/services/persondir/support/RegexGatewayPersonAttributeDaoTest.java
+++ b/person-directory-impl/src/test/java/org/apereo/services/persondir/support/RegexGatewayPersonAttributeDaoTest.java
@@ -21,13 +21,13 @@ package org.apereo.services.persondir.support;
 import org.apereo.services.persondir.AbstractPersonAttributeDaoTest;
 import org.apereo.services.persondir.IPersonAttributeDao;
 import org.apereo.services.persondir.IPersonAttributeDaoFilter;
+import org.apereo.services.persondir.IPersonAttributes;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@SuppressWarnings("deprecation")
 public class RegexGatewayPersonAttributeDaoTest extends AbstractPersonAttributeDaoTest {
 
     // Instance Members.
@@ -42,7 +42,7 @@ public class RegexGatewayPersonAttributeDaoTest extends AbstractPersonAttributeD
     public RegexGatewayPersonAttributeDaoTest() {
         this.attributes = new HashMap<>();
 
-        final List list = new ArrayList<>();
+        final List<Object> list = new ArrayList<>();
         list.add("(480) 555-1212");
         attributes.put("phone", list);
         this.enclosed = new StubPersonAttributeDao(attributes);
@@ -78,21 +78,20 @@ public class RegexGatewayPersonAttributeDaoTest extends AbstractPersonAttributeD
     }
 
     public void testMatches() {
-        final Map<String, List<Object>> results = target.getMultivaluedUserAttributes("monkey@yahoo.com", IPersonAttributeDaoFilter.alwaysChoose());
-        assertEquals(results, attributes);
+        final IPersonAttributes results = target.getPerson("monkey@yahoo.com", IPersonAttributeDaoFilter.alwaysChoose());
+        assertEquals(attributes, results.getAttributes());
     }
 
     public void testDoesNotMatch() {
-        final Map<String, List<Object>> results = target.getMultivaluedUserAttributes("monkey",
+        final IPersonAttributes results = target.getPerson("monkey",
             IPersonAttributeDaoFilter.alwaysChoose());
-        assertFalse(attributes.equals(results));
+        assertNull(results);
     }
 
     public void testGetPossibleNames() {
         assertEquals(enclosed.getPossibleUserAttributeNames(IPersonAttributeDaoFilter.alwaysChoose()),
             target.getPossibleUserAttributeNames(IPersonAttributeDaoFilter.alwaysChoose()));
     }
-
 
     @Override
     protected IPersonAttributeDao getPersonAttributeDaoInstance() {

--- a/person-directory-impl/src/test/java/org/apereo/services/persondir/support/ScriptEnginePersonAttributeDaoTest.java
+++ b/person-directory-impl/src/test/java/org/apereo/services/persondir/support/ScriptEnginePersonAttributeDaoTest.java
@@ -74,7 +74,20 @@ public class ScriptEnginePersonAttributeDaoTest extends AbstractPersonAttributeD
         final Set<IPersonAttributes> personSet = this.dao.getPeopleWithMultivaluedAttributes(query, IPersonAttributeDaoFilter.alwaysChoose());
         assertNotNull(personSet);
         assertEquals(1, personSet.size());
-        assertEquals("testuser", ((IPersonAttributes) personSet.iterator().next()).getName());
+        assertEquals("testuser", (personSet.iterator().next()).getName());
+    }
+
+    @Test
+    public void testGetMultiValuedAttributesWithExtraAttributesGroovy() {
+        this.dao.setScriptFile("SampleScriptedGroovyPersonAttributeDao.groovy");
+        final Map<String, List<Object>> query = new LinkedHashMap<>();
+        query.put("username", Util.list("testuser"));
+        query.put("current_attribute", Util.list("something"));
+        final Set<IPersonAttributes> personSet = this.dao.getPeopleWithMultivaluedAttributes(query, IPersonAttributeDaoFilter.alwaysChoose());
+        assertNotNull(personSet);
+        assertEquals(1, personSet.size());
+        assertEquals("testuser", (personSet.iterator().next()).getName());
+        assertEquals(Util.list("found_something"), (personSet.iterator().next()).getAttributes().get("new_attribute"));
     }
 
     @Test

--- a/person-directory-impl/src/test/java/org/apereo/services/persondir/support/StubPersonAttributeDaoTest.java
+++ b/person-directory-impl/src/test/java/org/apereo/services/persondir/support/StubPersonAttributeDaoTest.java
@@ -21,6 +21,7 @@ package org.apereo.services.persondir.support;
 import org.apereo.services.persondir.AbstractPersonAttributeDaoTest;
 import org.apereo.services.persondir.IPersonAttributeDao;
 import org.apereo.services.persondir.IPersonAttributeDaoFilter;
+import org.apereo.services.persondir.IPersonAttributes;
 import org.apereo.services.persondir.util.Util;
 
 import java.util.Collections;
@@ -72,14 +73,21 @@ public class StubPersonAttributeDaoTest
         assertEquals(Collections.EMPTY_SET, nullBacking.getPossibleUserAttributeNames(IPersonAttributeDaoFilter.alwaysChoose()));
     }
 
+    /**
+     * Return stub attributes regardless of input (e.g. empty map)
+     */
     public void testGetUserAttributesMap() {
-        assertEquals(this.backingMap, this.testInstance.getMultivaluedUserAttributes(new HashMap<String, List<Object>>(),
-            IPersonAttributeDaoFilter.alwaysChoose()));
+        final Set<IPersonAttributes> resultsSet = this.testInstance.getPeopleWithMultivaluedAttributes(new HashMap<>(),
+            IPersonAttributeDaoFilter.alwaysChoose());
+        assertEquals(this.backingMap, resultsSet.iterator().next().getAttributes());
 
     }
 
+    /**
+     * Return stub attributes regardless of uid, e.g. random name wombat.
+     */
     public void testGetUserAttributesString() {
-        assertEquals(this.backingMap, this.testInstance.getMultivaluedUserAttributes("wombat", IPersonAttributeDaoFilter.alwaysChoose()));
+        assertEquals(this.backingMap, this.testInstance.getPerson("wombat", IPersonAttributeDaoFilter.alwaysChoose()).getAttributes());
     }
 
     @Override

--- a/person-directory-impl/src/test/java/org/apereo/services/persondir/support/jdbc/MultiRowJdbcPersonAttributeDaoTest.java
+++ b/person-directory-impl/src/test/java/org/apereo/services/persondir/support/jdbc/MultiRowJdbcPersonAttributeDaoTest.java
@@ -20,7 +20,9 @@ package org.apereo.services.persondir.support.jdbc;
 
 import com.google.common.collect.ImmutableMap;
 import junit.framework.TestCase;
+import org.apereo.services.persondir.IPersonAttributeDao;
 import org.apereo.services.persondir.IPersonAttributeDaoFilter;
+import org.apereo.services.persondir.IPersonAttributes;
 import org.apereo.services.persondir.support.AbstractDefaultAttributePersonAttributeDao;
 import org.apereo.services.persondir.support.SimpleUsernameAttributeProvider;
 import org.apereo.services.persondir.util.CaseCanonicalizationMode;
@@ -195,7 +197,7 @@ public class MultiRowJdbcPersonAttributeDaoTest
         impl.setNameValueColumnMappings(Collections.singletonMap("attr_name", "attr_val"));
 
 
-        final Map<String, List<Object>> attribs = impl.getMultivaluedUserAttributes("awp9", IPersonAttributeDaoFilter.alwaysChoose());
+        final Map<String, List<Object>> attribs = impl.getPerson("awp9", IPersonAttributeDaoFilter.alwaysChoose()).getAttributes();
         TestCase.assertEquals(Util.list("andrew.petro@yale.edu"), attribs.get("email"));
         TestCase.assertEquals(Util.list("andrew.petro@yale.edu"), attribs.get("emailAddress"));
         TestCase.assertEquals(Util.list("blue"), attribs.get("dressShirtColor"));
@@ -254,7 +256,7 @@ public class MultiRowJdbcPersonAttributeDaoTest
         impl.setNameValueColumnMappings(Collections.singletonMap("attr_name", "attr_val"));
 
 
-        final Map<String, List<Object>> attribs = impl.getMultivaluedUserAttributes("awp9", IPersonAttributeDaoFilter.alwaysChoose());
+        final Map<String, List<Object>> attribs = impl.getPerson("awp9", IPersonAttributeDaoFilter.alwaysChoose()).getAttributes();
         TestCase.assertEquals(Util.list("andrew.petro@yale.edu"), attribs.get("email"));
         TestCase.assertEquals(Util.list("andrew.petro@yale.edu"), attribs.get("emailAddress"));
         TestCase.assertEquals(Util.list("blue"), attribs.get("dressShirtColor"));
@@ -281,7 +283,7 @@ public class MultiRowJdbcPersonAttributeDaoTest
         impl.setNameValueColumnMappings(Collections.singletonMap("attr_nam", "attr_val"));
 
         try {
-            impl.getMultivaluedUserAttributes("awp9", IPersonAttributeDaoFilter.alwaysChoose());
+            impl.getPerson("awp9", IPersonAttributeDaoFilter.alwaysChoose());
             TestCase.fail("BadSqlGrammarException expected with invalid attribute mapping key");
         } catch (final BadSqlGrammarException bsge) {
             //expected
@@ -291,7 +293,7 @@ public class MultiRowJdbcPersonAttributeDaoTest
         impl.setNameValueColumnMappings(Collections.singletonMap("attr_name", "attr_va"));
 
         try {
-            impl.getMultivaluedUserAttributes("awp9", IPersonAttributeDaoFilter.alwaysChoose());
+            impl.getPerson("awp9", IPersonAttributeDaoFilter.alwaysChoose());
             TestCase.fail("BadSqlGrammarException expected with invalid attribute mapping key");
         } catch (final BadSqlGrammarException bsge) {
             //expected
@@ -320,7 +322,7 @@ public class MultiRowJdbcPersonAttributeDaoTest
 
         impl.setNameValueColumnMappings(Collections.singletonMap("attr_name", "attr_val"));
 
-        final Map<String, List<Object>> attribs = impl.getMultivaluedUserAttributes("awp9", IPersonAttributeDaoFilter.alwaysChoose());
+        final Map<String, List<Object>> attribs = impl.getPerson("awp9", IPersonAttributeDaoFilter.alwaysChoose()).getAttributes();
         TestCase.assertEquals(Util.list("andrew.petro@yale.edu"), attribs.get("email"));
         TestCase.assertEquals(Util.list("andrew.petro@yale.edu"), attribs.get("emailAddress"));
         TestCase.assertEquals(Util.list("blue"), attribs.get("shirt_color"));
@@ -365,7 +367,7 @@ public class MultiRowJdbcPersonAttributeDaoTest
 
         impl.setNameValueColumnMappings(Collections.singletonMap("attr_name", "attr_val"));
 
-        final Map<String, List<Object>> attribs = impl.getMultivaluedUserAttributes("susan", IPersonAttributeDaoFilter.alwaysChoose());
+        final Map<String, List<Object>> attribs = impl.getPerson("susan", IPersonAttributeDaoFilter.alwaysChoose()).getAttributes();
         TestCase.assertEquals(Collections.singletonList(null), attribs.get("dressShirtColor"));
         TestCase.assertEquals(Util.list("Susan"), attribs.get("firstName"));
     }
@@ -396,8 +398,8 @@ public class MultiRowJdbcPersonAttributeDaoTest
         queryMap.put("shirtColor", Util.list("blue"));
         queryMap.put("Name", Util.list("John"));
 
-        final Map<String, List<Object>> attribs = impl.getMultivaluedUserAttributes(queryMap, IPersonAttributeDaoFilter.alwaysChoose());
-        TestCase.assertEquals(Util.list("blue"), attribs.get("color"));
+        final Set<IPersonAttributes> attribsSet = impl.getPeopleWithMultivaluedAttributes(queryMap, IPersonAttributeDaoFilter.alwaysChoose());
+        TestCase.assertEquals(Util.list("blue"), attribsSet.iterator().next().getAttributes().get("color"));
     }
 
     /**
@@ -431,8 +433,8 @@ public class MultiRowJdbcPersonAttributeDaoTest
         queryMap.put("uid", Util.list("awp9"));
         queryMap.put("Name", Util.list("John"));
 
-        final Map<String, List<Object>> attribs = impl.getMultivaluedUserAttributes(queryMap, IPersonAttributeDaoFilter.alwaysChoose());
-        TestCase.assertNull(attribs);
+        Set<IPersonAttributes> attribsSet = impl.getPeopleWithMultivaluedAttributes(queryMap, IPersonAttributeDaoFilter.alwaysChoose());
+        TestCase.assertNull(attribsSet);
     }
 
     public void testProperties() {

--- a/person-directory-impl/src/test/java/org/apereo/services/persondir/support/jdbc/PostgresSingleRowJdbcPersonAttributeDaoTest.java
+++ b/person-directory-impl/src/test/java/org/apereo/services/persondir/support/jdbc/PostgresSingleRowJdbcPersonAttributeDaoTest.java
@@ -20,6 +20,7 @@ package org.apereo.services.persondir.support.jdbc;
 
 import junit.framework.TestResult;
 import org.apereo.services.persondir.IPersonAttributeDaoFilter;
+import org.apereo.services.persondir.IPersonAttributes;
 import org.apereo.services.persondir.support.AbstractDefaultAttributePersonAttributeDao;
 import org.apereo.services.persondir.support.SimpleUsernameAttributeProvider;
 import org.apereo.services.persondir.util.Util;
@@ -131,7 +132,7 @@ public class PostgresSingleRowJdbcPersonAttributeDaoTest extends AbstractCaseSen
         columnsToAttributes.put("shirt_color", "dressShirtColor");
         impl.setResultAttributeMapping(columnsToAttributes);
 
-        final Map<String, List<Object>> attribs = impl.getMultivaluedUserAttributes("awp9", IPersonAttributeDaoFilter.alwaysChoose());
+        final Map<String, List<Object>> attribs = impl.getPerson("awp9", IPersonAttributeDaoFilter.alwaysChoose()).getAttributes();
         assertEquals(Util.list("andrew.petro@yale.edu"), attribs.get("email"));
         assertEquals(Util.list("andrew.petro@yale.edu"), attribs.get("emailAddress"));
         assertEquals(Util.list("blue"), attribs.get("dressShirtColor"));
@@ -188,7 +189,7 @@ public class PostgresSingleRowJdbcPersonAttributeDaoTest extends AbstractCaseSen
         columnsToAttributes.put("locations", "locations");
         impl.setResultAttributeMapping(columnsToAttributes);
 
-        final Map<String, List<Object>> attribs = impl.getMultivaluedUserAttributes("awp9", IPersonAttributeDaoFilter.alwaysChoose());
+        final Map<String, List<Object>> attribs = impl.getPerson("awp9", IPersonAttributeDaoFilter.alwaysChoose()).getAttributes();
         assertEquals(Util.list("andrew.petro@yale.edu"), attribs.get("email"));
         assertEquals(Util.list("andrew.petro@yale.edu"), attribs.get("emailAddress"));
         assertEquals(Util.list("blue"), attribs.get("dressShirtColor"));
@@ -211,7 +212,7 @@ public class PostgresSingleRowJdbcPersonAttributeDaoTest extends AbstractCaseSen
         columnsToAttributes.put("email", "emailAddress");
         impl.setResultAttributeMapping(columnsToAttributes);
 
-        final Map<String, List<Object>> attribs = impl.getMultivaluedUserAttributes("awp9", IPersonAttributeDaoFilter.alwaysChoose());
+        final Map<String, List<Object>> attribs = impl.getPerson("awp9", IPersonAttributeDaoFilter.alwaysChoose()).getAttributes();
         assertEquals(Util.list("andrew.petro@yale.edu"), attribs.get("emailAddress"));
         assertEquals(Util.list("Andrew"), attribs.get("firstName"));
     }
@@ -235,7 +236,7 @@ public class PostgresSingleRowJdbcPersonAttributeDaoTest extends AbstractCaseSen
         columnsToAttributes.put("shirt_color", null);
         impl.setResultAttributeMapping(columnsToAttributes);
 
-        final Map<String, List<Object>> attribs = impl.getMultivaluedUserAttributes("awp9", IPersonAttributeDaoFilter.alwaysChoose());
+        final Map<String, List<Object>> attribs = impl.getPerson("awp9", IPersonAttributeDaoFilter.alwaysChoose()).getAttributes();
         assertEquals(Util.list("andrew.petro@yale.edu"), attribs.get("email"));
         assertEquals(Util.list("andrew.petro@yale.edu"), attribs.get("emailAddress"));
         assertEquals(Util.list("blue"), attribs.get("shirt_color"));
@@ -274,7 +275,7 @@ public class PostgresSingleRowJdbcPersonAttributeDaoTest extends AbstractCaseSen
         columnsToAttributes.put("shirt_color", "dressShirtColor");
         impl.setResultAttributeMapping(columnsToAttributes);
 
-        final Map<String, List<Object>> attribs = impl.getMultivaluedUserAttributes("susan", IPersonAttributeDaoFilter.alwaysChoose());
+        final Map<String, List<Object>> attribs = impl.getPerson("susan", IPersonAttributeDaoFilter.alwaysChoose()).getAttributes();
         assertNull(attribs.get("dressShirtColor"));
         assertEquals(Util.list("Susan"), attribs.get("firstName"));
     }
@@ -306,11 +307,13 @@ public class PostgresSingleRowJdbcPersonAttributeDaoTest extends AbstractCaseSen
         queryMap.put("shirtColor", Util.list("blue"));
         queryMap.put("Name", Util.list("John"));
 
-        final Map<String, List<Object>> attribs = impl.getMultivaluedUserAttributes(queryMap, IPersonAttributeDaoFilter.alwaysChoose());
-        assertNotNull(attribs);
-        assertEquals(Util.list("andrew.petro@yale.edu"), attribs.get("email"));
-        assertEquals(Util.list("andrew.petro@yale.edu"), attribs.get("emailAddress"));
-        assertEquals(Util.list("Andrew"), attribs.get("firstName"));
+        final Set<IPersonAttributes> attribsSet = impl.getPeopleWithMultivaluedAttributes(queryMap, IPersonAttributeDaoFilter.alwaysChoose());
+        assertEquals(1, attribsSet.size());
+        IPersonAttributes result = attribsSet.iterator().next();
+        assertNotNull(result.getAttributes());
+        assertEquals(Util.list("andrew.petro@yale.edu"), result.getAttributes().get("email"));
+        assertEquals(Util.list("andrew.petro@yale.edu"), result.getAttributes().get("emailAddress"));
+        assertEquals(Util.list("Andrew"), result.getAttributes().get("firstName"));
     }
 
     /**
@@ -339,8 +342,8 @@ public class PostgresSingleRowJdbcPersonAttributeDaoTest extends AbstractCaseSen
         queryMap.put("uid", Util.list("awp9"));
         queryMap.put("Name", Util.list("John"));
 
-        final Map<String, List<Object>> attribs = impl.getMultivaluedUserAttributes(queryMap, IPersonAttributeDaoFilter.alwaysChoose());
-        assertNull(attribs);
+        final Set<IPersonAttributes> attribsSet = impl.getPeopleWithMultivaluedAttributes(queryMap, IPersonAttributeDaoFilter.alwaysChoose());
+        assertNull(attribsSet);
     }
 
     /**
@@ -366,7 +369,7 @@ public class PostgresSingleRowJdbcPersonAttributeDaoTest extends AbstractCaseSen
         queryMap.put("shirt", Util.list("blue"));
 
         try {
-            impl.getMultivaluedUserAttributes(queryMap, IPersonAttributeDaoFilter.alwaysChoose());
+            impl.getPeopleWithMultivaluedAttributes(queryMap, IPersonAttributeDaoFilter.alwaysChoose());
         } catch (final IncorrectResultSizeDataAccessException irsdae) {
             // good, exception thrown for multiple results
             return;

--- a/person-directory-impl/src/test/java/org/apereo/services/persondir/support/ldap/LdapPersonAttributeDaoTest.java
+++ b/person-directory-impl/src/test/java/org/apereo/services/persondir/support/ldap/LdapPersonAttributeDaoTest.java
@@ -28,8 +28,8 @@ import org.apache.directory.server.core.annotations.CreatePartition;
 import org.apache.directory.server.core.integ.AbstractLdapTestUnit;
 import org.apache.directory.server.core.integ.FrameworkRunner;
 import org.apereo.services.persondir.IPersonAttributeDaoFilter;
+import org.apereo.services.persondir.IPersonAttributes;
 import org.apereo.services.persondir.util.Util;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -123,7 +123,7 @@ public class LdapPersonAttributeDaoTest extends AbstractLdapTestUnit {
      * Create a Spring-LDAP ContextSource for the in-memory LDAP server
      */
     @BeforeClass
-    public static void initontextSource() {
+    public static void initContextSource() {
         LdapContextSource ctxSrc = new LdapContextSource();
         ctxSrc.setUrl("ldap://localhost:10200");
         ctxSrc.setBase("DC=example,DC=com");
@@ -156,8 +156,8 @@ public class LdapPersonAttributeDaoTest extends AbstractLdapTestUnit {
         queryMap.put("uid", Util.list("unknown"));
 
         try {
-            final Map<String, List<Object>> attribs = impl.getMultivaluedUserAttributes(queryMap, IPersonAttributeDaoFilter.alwaysChoose());
-            assertNull(attribs);
+            final Set<IPersonAttributes> attribs = impl.getPeopleWithMultivaluedAttributes(queryMap, IPersonAttributeDaoFilter.alwaysChoose());
+            assertEquals(0, attribs.size());
         } catch (final DataAccessResourceFailureException darfe) {
             //OK, No net connection
         }
@@ -185,8 +185,9 @@ public class LdapPersonAttributeDaoTest extends AbstractLdapTestUnit {
         queryMap.put("uid", Util.list("edalquist"));
 
         try {
-            final Map<String, List<Object>> attribs = impl.getMultivaluedUserAttributes(queryMap, IPersonAttributeDaoFilter.alwaysChoose());
-            assertEquals(Util.list("eric.dalquist@example.com"), attribs.get("email"));
+            final Set<IPersonAttributes> attribsSet = impl.getPeopleWithMultivaluedAttributes(queryMap, IPersonAttributeDaoFilter.alwaysChoose());
+            IPersonAttributes attribs = attribsSet.iterator().next();
+            assertEquals(Util.list("eric.dalquist@example.com"), attribs.getAttributes().get("email"));
         } catch (final DataAccessResourceFailureException darfe) {
             //OK, No net connection
         }
@@ -220,9 +221,10 @@ public class LdapPersonAttributeDaoTest extends AbstractLdapTestUnit {
         queryMap.put("uid", Util.list("edalquist"));
 
         try {
-            final Map<String, List<Object>> attribs = impl.getMultivaluedUserAttributes(queryMap, IPersonAttributeDaoFilter.alwaysChoose());
-            assertEquals(Util.list("eric.dalquist@example.com"), attribs.get("email"));
-            assertEquals(Util.list("eric.dalquist@example.com"), attribs.get("work.email"));
+            final Set<IPersonAttributes> attribsSet = impl.getPeopleWithMultivaluedAttributes(queryMap, IPersonAttributeDaoFilter.alwaysChoose());
+            IPersonAttributes attribs = attribsSet.iterator().next();
+            assertEquals(Util.list("eric.dalquist@example.com"), attribs.getAttributes().get("email"));
+            assertEquals(Util.list("eric.dalquist@example.com"), attribs.getAttributes().get("work.email"));
         } catch (final DataAccessResourceFailureException darfe) {
             //OK, No net connection
         }
@@ -247,8 +249,8 @@ public class LdapPersonAttributeDaoTest extends AbstractLdapTestUnit {
         queryMap.put("uid", Util.list("edalquist"));
 
         try {
-            final Map<String, List<Object>> attribs = impl.getMultivaluedUserAttributes(queryMap, IPersonAttributeDaoFilter.alwaysChoose());
-            assertNull(attribs.get("email"));
+            final Set<IPersonAttributes> attribsSet = impl.getPeopleWithMultivaluedAttributes(queryMap, IPersonAttributeDaoFilter.alwaysChoose());
+            assertNull(attribsSet.iterator().next().getAttributes().get("email"));
         } catch (final DataAccessResourceFailureException darfe) {
             //OK, No net connection
         }
@@ -273,8 +275,8 @@ public class LdapPersonAttributeDaoTest extends AbstractLdapTestUnit {
         queryMap.put("uid", Util.list("edalquist"));
 
         try {
-            final Map<String, List<Object>> attribs = impl.getMultivaluedUserAttributes(queryMap, IPersonAttributeDaoFilter.alwaysChoose());
-            assertEquals(Util.list("eric.dalquist@example.com"), attribs.get("mail"));
+            final Set<IPersonAttributes> attribsSet = impl.getPeopleWithMultivaluedAttributes(queryMap, IPersonAttributeDaoFilter.alwaysChoose());
+            assertEquals(Util.list("eric.dalquist@example.com"), attribsSet.iterator().next().getAttributes().get("mail"));
         } catch (final DataAccessResourceFailureException darfe) {
             //OK, No net connection
         }
@@ -308,8 +310,8 @@ public class LdapPersonAttributeDaoTest extends AbstractLdapTestUnit {
         queryMap.put("email", Util.list("edalquist@unicon.net"));
 
         try {
-            final Map<String, List<Object>> attribs = impl.getMultivaluedUserAttributes(queryMap, IPersonAttributeDaoFilter.alwaysChoose());
-            assertEquals(Util.list("eric.dalquist@example.com"), attribs.get("email"));
+            final Set<IPersonAttributes> attribsSet = impl.getPeopleWithMultivaluedAttributes(queryMap, IPersonAttributeDaoFilter.alwaysChoose());
+            assertEquals(Util.list("eric.dalquist@example.com"), attribsSet.iterator().next().getAttributes().get("email"));
         } catch (final DataAccessResourceFailureException darfe) {
             //OK, No net connection
         }
@@ -339,8 +341,8 @@ public class LdapPersonAttributeDaoTest extends AbstractLdapTestUnit {
         queryMap.put("uid", Util.list("edalquist"));
         queryMap.put("email", Util.list("edalquist@example.net"));
 
-        final Map<String, List<Object>> attribs = impl.getMultivaluedUserAttributes(queryMap, IPersonAttributeDaoFilter.alwaysChoose());
-        assertNull(attribs);
+        final Set<IPersonAttributes> attribsSet = impl.getPeopleWithMultivaluedAttributes(queryMap, IPersonAttributeDaoFilter.alwaysChoose());
+        assertNull(attribsSet);
     }
 
     /**

--- a/person-directory-impl/src/test/java/org/apereo/services/persondir/support/rule/DeclaredRulePersonAttributeDaoTest.java
+++ b/person-directory-impl/src/test/java/org/apereo/services/persondir/support/rule/DeclaredRulePersonAttributeDaoTest.java
@@ -21,16 +21,14 @@ package org.apereo.services.persondir.support.rule;
 import org.apereo.services.persondir.AbstractPersonAttributeDaoTest;
 import org.apereo.services.persondir.IPersonAttributeDao;
 import org.apereo.services.persondir.IPersonAttributeDaoFilter;
+import org.apereo.services.persondir.IPersonAttributes;
 import org.apereo.services.persondir.util.Util;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
-@SuppressWarnings("deprecation")
 public class DeclaredRulePersonAttributeDaoTest extends AbstractPersonAttributeDaoTest {
 
     private static final String NAME = "eduPersonPrimaryAffiliation";
@@ -85,13 +83,13 @@ public class DeclaredRulePersonAttributeDaoTest extends AbstractPersonAttributeD
     }
 
     public void testMatches() {
-        final Map<String, List<Object>> results = target.getMultivaluedUserAttributes("records-staff", IPersonAttributeDaoFilter.alwaysChoose());
-        assertNotNull(results);
-        assertEquals(Util.list(VALUE), results.get("fax"));
+        final IPersonAttributes results = target.getPerson("records-staff", IPersonAttributeDaoFilter.alwaysChoose());
+        assertNotNull(results.getAttributes());
+        assertEquals(Util.list(VALUE), results.getAttributes().get("fax"));
     }
 
     public void testDoesNotMatch() {
-        final Map<String, List<Object>> results = target.getMultivaluedUserAttributes("faculty", IPersonAttributeDaoFilter.alwaysChoose());
+        final IPersonAttributes results = target.getPerson("faculty", IPersonAttributeDaoFilter.alwaysChoose());
         assertNull(results);
     }
 

--- a/person-directory-impl/src/test/resources/SampleScriptedGroovyPersonAttributeDao.groovy
+++ b/person-directory-impl/src/test/resources/SampleScriptedGroovyPersonAttributeDao.groovy
@@ -3,8 +3,15 @@ import java.util.*
 Map<String, List<Object>> run(final Object... args) {
     def uid = args[0]
     def logger = args[1]
+    Map currentAttributes = args[2]
+
+    List currentAttributeList = currentAttributes.get("current_attribute");
+    def newAttribute = currentAttributeList != null && !currentAttributeList.isEmpty() ? "found_" + currentAttributeList.get(0) : null
 
     logger.debug("Things are happening just fine with uid: " + uid)
-    return[username:[uid], likes:["cheese", "food"], id:[1234,2,3,4,5], another:"attribute"]
+    def returnMap = [username:[uid], likes:["cheese", "food"], id:[1234,2,3,4,5], another:"attribute"]
+    if (newAttribute != null)
+        returnMap.put("new_attribute", [newAttribute])
+    return returnMap
 }
 


### PR DESCRIPTION
I remove all deprecated methods, most were deprecated in 2008. I updated tests that used old methods to use nearest replacement. 

I included the method name in caching key so return the type
of different methods won't be result in runtime error by pulling
object out of cache and returning it for method that
should return a different type (e.g. Set<IPersonAttributes> vs IPersonAttributes)
