### PR TITLE
ldap dao tests and warn logging

### DIFF
--- a/person-directory-impl/src/main/java/org/apereo/services/persondir/support/AbstractAggregatingDefaultQueryPersonAttributeDao.java
+++ b/person-directory-impl/src/main/java/org/apereo/services/persondir/support/AbstractAggregatingDefaultQueryPersonAttributeDao.java
@@ -223,7 +223,7 @@ public abstract class AbstractAggregatingDefaultQueryPersonAttributeDao extends 
      * @param currentlyConsidering The IPersonAttributeDao to execute the query on.
      * @param resultPeople         The Map of results from all previous queries, may be null.
      * @param filter               the filter
-     * @return The results from the call to the DAO, follows the same rules as {@link IPersonAttributeDao#getUserAttributes(Map, IPersonAttributeDaoFilter)}.
+     * @return The results from the call to the DAO.
      */
     protected abstract Set<IPersonAttributes> getAttributesFromDao(Map<String, List<Object>> seed, boolean isFirstQuery,
                                                                    IPersonAttributeDao currentlyConsidering,

--- a/person-directory-impl/src/main/java/org/apereo/services/persondir/support/ldap/LdaptivePersonAttributeDao.java
+++ b/person-directory-impl/src/main/java/org/apereo/services/persondir/support/ldap/LdaptivePersonAttributeDao.java
@@ -152,6 +152,15 @@ public class LdaptivePersonAttributeDao extends AbstractQueryPersonAttributeDao<
         } else {
             query = filter;
         }
+
+        if (this.isUseAllQueryAttributes() &&
+            values.size() > 1 &&
+            (this.searchFilter.contains("{0}") ||
+             this.searchFilter.contains("{user}"))) {
+            logger.warn("Query value will be indeterminate due to multiple attributes and no username indicator. Use attribute [{}] in query instead of {0} or {user}",
+                attribute);
+        }
+
         if (values.size() > 0) {
             if (this.searchFilter.contains("{0}")) {
                 query.setParameter(0, values.get(0).toString());


### PR DESCRIPTION
This adds test cases demonstrating ways to use ldap filter with multiple args (either by specifying the username or using a search filter that references the correct attribute name in braces (rather than {0} or {user}. 
Adds warning if using ldap dao with multiple args, no username attribute specified, and a filter that uses the single arg values {0} or {user}.