### PR TITLE
Add binary attributes to Ldaptive request

### DIFF
--- a/person-directory-impl/src/main/java/org/apereo/services/persondir/support/ldap/LdaptivePersonAttributeDao.java
+++ b/person-directory-impl/src/main/java/org/apereo/services/persondir/support/ldap/LdaptivePersonAttributeDao.java
@@ -77,6 +77,11 @@ public class LdaptivePersonAttributeDao extends AbstractQueryPersonAttributeDao<
      */
     private String searchFilter;
 
+    /**
+     * LDAP binary attributes.
+     */
+    private String[] binaryAttributes;
+
     public LdaptivePersonAttributeDao() {
         super();
     }
@@ -118,6 +123,15 @@ public class LdaptivePersonAttributeDao extends AbstractQueryPersonAttributeDao<
      */
     public void setConnectionFactory(final ConnectionFactory connectionFactory) {
         this.connectionFactory = connectionFactory;
+    }
+
+    /**
+     * Sets binary attributes.
+     *
+     * @param binary attributes array.
+     */
+    public void setBinaryAttributes(final String[] binaryAttributes) {
+        this.binaryAttributes = binaryAttributes;
     }
 
     @Override
@@ -184,6 +198,7 @@ public class LdaptivePersonAttributeDao extends AbstractQueryPersonAttributeDao<
         final SearchRequest request = new SearchRequest();
         request.setBaseDn(this.baseDN);
         request.setFilter(filter);
+        request.setBinaryAttributes(binaryAttributes);
 
         /** LDAP attributes to fetch from search results. */
         if (getResultAttributeMapping() != null && !getResultAttributeMapping().isEmpty()) {


### PR DESCRIPTION
Adds binary attributes to Ldaptive request dao in order to properly process binary attributes.