### PR TITLE
add onPremisesSamAccountName user attribute

### DIFF
--- a/person-directory-impl/src/main/java/org/apereo/services/persondir/support/MicrosoftGraphPersonAttributeDao.java
+++ b/person-directory-impl/src/main/java/org/apereo/services/persondir/support/MicrosoftGraphPersonAttributeDao.java
@@ -353,6 +353,8 @@ public class MicrosoftGraphPersonAttributeDao extends BasePersonAttributeDao {
         private String faxNumber;
 
         private String mailNickname;
+        
+        private String onPremisesSamAccountName;
 
         @JsonIgnore
         static String getFieldQuery() {


### PR DESCRIPTION
onPremisesSamAccountName is the user on premise id. It can be very useful for companies transitioning from on prem to azure or using an hybrid model