### PR TITLE
Remove Apache HttpClient in favor of OkHttp

### DIFF
--- a/person-directory-impl/pom.xml
+++ b/person-directory-impl/pom.xml
@@ -85,17 +85,16 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>retrofit</artifactId>
         </dependency>
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-moshi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>

--- a/person-directory-impl/src/main/java/org/apereo/services/persondir/support/cache/AttributeBasedCacheKeyGenerator.java
+++ b/person-directory-impl/src/main/java/org/apereo/services/persondir/support/cache/AttributeBasedCacheKeyGenerator.java
@@ -18,8 +18,8 @@
  */
 package org.apereo.services.persondir.support.cache;
 
+import okio.ByteString;
 import org.aopalliance.intercept.MethodInvocation;
-import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
 import org.apache.commons.logging.Log;
@@ -36,8 +36,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-
-import static org.apache.commons.codec.digest.MessageDigestAlgorithms.*;
 
 public class AttributeBasedCacheKeyGenerator implements CacheKeyGenerator {
 
@@ -302,7 +300,7 @@ public class AttributeBasedCacheKeyGenerator implements CacheKeyGenerator {
     }
 
     private void putAttributeInCache(final Map<String, Object> cacheKey, final String attr, final Object value) {
-        var hexed = new DigestUtils(SHA_512).digestAsHex(value.toString());
+        var hexed = ByteString.encodeUtf8(value.toString()).sha512().hex();
         cacheKey.put(hexed, value);
     }
 

--- a/person-directory-impl/src/test/java/org/apereo/services/persondir/support/RestfulPersonAttributeDaoTest.java
+++ b/person-directory-impl/src/test/java/org/apereo/services/persondir/support/RestfulPersonAttributeDaoTest.java
@@ -40,9 +40,18 @@ public class RestfulPersonAttributeDaoTest extends AbstractPersonAttributeDaoTes
     }
 
     @Test
-    public void testGetAttributes() {
+    public void testGetAttributes_get() {
         this.dao.setUrl("http://localhost:8080/test");
         this.dao.setMethod(HttpMethod.GET.name());
+        var person = this.dao.getPerson("something");
+        assertEquals(person.getName(), "something");
+        assertEquals(person.getAttributes().size(), 2);
+    }
+
+    @Test
+    public void testGetAttributes_post() {
+        this.dao.setUrl("http://localhost:8080/test");
+        this.dao.setMethod(HttpMethod.POST.name());
         var person = this.dao.getPerson("something");
         assertEquals(person.getName(), "something");
         assertEquals(person.getAttributes().size(), 2);

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,6 @@
         <jackson.version>2.15.2</jackson.version>
         <commons-io.version>2.13.0</commons-io.version>
         <ldaptive.version>2.1.2</ldaptive.version>
-        <apachehttpclient>4.5.14</apachehttpclient>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -125,11 +124,6 @@
                 <artifactId>oauth2-useragent</artifactId>
                 <version>0.11.3</version>
                 <scope>compile</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.httpcomponents</groupId>
-                <artifactId>httpclient</artifactId>
-                <version>${apachehttpclient}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
The library currently has dependencies on both Apache Httpclient and OkHttp (through Retrofit).

This removes the dependency on Apache HttpClient and uses OkHttp for all HTTP requests.