### PR TITLE
don't implement method with do-nothing default

### DIFF
--- a/person-directory-api/src/main/java/org/apereo/services/persondir/IPersonAttributeDao.java
+++ b/person-directory-api/src/main/java/org/apereo/services/persondir/IPersonAttributeDao.java
@@ -125,11 +125,9 @@ public interface IPersonAttributeDao extends Comparable<IPersonAttributeDao>, Or
      * @return A {@link Set} of {@link IPersonAttributes}s that match the query {@link Map}. If no matches are found an empty {@link Set} is returned. If the query could not be run null is returned.
      * @throws IllegalArgumentException If <code>query</code> is <code>null.</code>
      */
-    default Set<IPersonAttributes> getPeopleWithMultivaluedAttributes(final Map<String, List<Object>> query,
+    Set<IPersonAttributes> getPeopleWithMultivaluedAttributes(final Map<String, List<Object>> query,
                                                                       final IPersonAttributeDaoFilter filter,
-                                                                      final Set<IPersonAttributes> resultPeople) {
-        return new LinkedHashSet<>(0);
-    }
+                                                                      final Set<IPersonAttributes> resultPeople);
 
     default Set<IPersonAttributes> getPeopleWithMultivaluedAttributes(final Map<String, List<Object>> query,
                                                                       final IPersonAttributeDaoFilter filter) {


### PR DESCRIPTION
I don't feel too strongly about this, but I think that people upgrading from CAS 6 to CAS 7 that have any custom person attribute DAOs will be overriding the wrong method and they will silently get no results so this takes away the default implementation and forces them to implement the correct method. The API module doesn't have SLF4J as a dependency other-wise I would have logged a warning. 